### PR TITLE
Fix broken npm self-upgrade in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,13 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile # Use frozen lockfile for reliability in CI
 
-      # Ensure npm 11.5.1+ for trusted publishing (OIDC)
+      # Ensure npm 11.5.1+ for trusted publishing (OIDC).
+      # The runner's pre-installed npm can have broken internal deps (MODULE_NOT_FOUND),
+      # so we use corepack to get a clean, up-to-date npm instead.
       - name: Update npm for trusted publishing
-        run: npm install -g npm@latest
+        run: |
+          corepack enable npm
+          corepack install -g npm@latest
 
       # Canary release: Create and publish snapshot release
       - name: Create and publish canary snapshot release


### PR DESCRIPTION
## Summary
- Replace `npm install -g npm@latest` with `corepack enable npm` + `corepack install -g npm@latest` in the release workflow
- Fixes `MODULE_NOT_FOUND: Cannot find module 'promise-retry'` error caused by the GitHub Actions runner's corrupted pre-installed npm on Node 22

## Test plan
- [ ] Verify the release workflow passes on the next push to `main`

Made with [Cursor](https://cursor.com)