### PR TITLE
Add appeal lifecycle E2E coverage

### DIFF
--- a/.changeset/appeal-lifecycle-e2e.md
+++ b/.changeset/appeal-lifecycle-e2e.md
@@ -1,0 +1,5 @@
+---
+"dsar": patch
+---
+
+Add refused request appeal overturn handling and backend E2E coverage for the full appeal-to-fulfilment lifecycle.

--- a/packages/backend/src/lifecycle/clock.ts
+++ b/packages/backend/src/lifecycle/clock.ts
@@ -6,7 +6,7 @@ import type {
 	RequestRecord,
 	RequestTimelineEventRecord,
 } from "@dsar/persistence";
-import type { Effect } from "effect/Effect";
+import type * as Effect from "effect/Effect";
 
 import { computeLegalClock } from "../services/legal-clock/engine";
 import type { LegalClockComputation } from "../services/legal-clock/engine";
@@ -41,6 +41,7 @@ export const addDays = (iso: string, days: number) => {
 };
 
 type LifecycleEventType =
+	| "appeal_overturned"
 	| "clarification_requested"
 	| "clarification_received"
 	| "deadline_extended"
@@ -58,6 +59,9 @@ type LifecycleEventType =
  */
 export const toEventType = (action: LifecycleAction): LifecycleEventType => {
 	switch (action) {
+		case "appeal_overturn": {
+			return "appeal_overturned";
+		}
 		case "clarification_request": {
 			return "clarification_requested";
 		}

--- a/packages/backend/src/lifecycle/state-machine.ts
+++ b/packages/backend/src/lifecycle/state-machine.ts
@@ -28,6 +28,7 @@ const LIFECYCLE_ACTIONS = [
 	"clarification_request",
 	"clarification_receive",
 	"extension",
+	"appeal_overturn",
 	"fulfil",
 	"refuse",
 	"close",
@@ -41,6 +42,7 @@ const LIFECYCLE_ACTIONS = [
 export type LifecycleAction = (typeof LIFECYCLE_ACTIONS)[number];
 
 const transitions: Record<LifecycleAction, readonly LifecycleStatus[]> = {
+	appeal_overturn: ["refused"],
 	clarification_receive: ["in_progress"],
 	clarification_request: ["in_progress", "verification_pending"],
 	close: ["fulfilled", "refused"],
@@ -55,6 +57,7 @@ const transitions: Record<LifecycleAction, readonly LifecycleStatus[]> = {
 const rationaleRequired = new Set<LifecycleAction>(["extension", "refuse"]);
 
 const statusByAction: Record<LifecycleAction, LifecycleStatus> = {
+	appeal_overturn: "in_progress",
 	clarification_receive: "in_progress",
 	clarification_request: "in_progress",
 	close: "closed",

--- a/packages/backend/src/routes/requests.ts
+++ b/packages/backend/src/routes/requests.ts
@@ -1985,6 +1985,15 @@ const rawRequestRoutes: readonly RouteDefinition[] = [
 						})
 					);
 				}
+				if (current.status === "closed") {
+					return yield* Effect.fail(
+						new RequestValidationError({
+							message: `Appeal ${appealId} cannot be decided because request ${requestId} is closed.`,
+							reasonCode:
+								backendErrorCatalogByCode.REQUEST_VALIDATION_FAILED.code,
+						})
+					);
+				}
 				const now = yield* currentIsoTime;
 				const DECISION_TO_STATUS: Readonly<Record<string, string>> = {
 					approve: "approved",
@@ -1992,6 +2001,8 @@ const rawRequestRoutes: readonly RouteDefinition[] = [
 					partial: "partially_approved",
 				};
 				const nextStatus = DECISION_TO_STATUS[decision];
+				const shouldOverturnRefusal =
+					decision === "approve" && current.status === "refused";
 				const nextAppeals: readonly JsonValue[] = existingAppeals.map(
 					(appeal, index) => {
 						if (index !== appealIndex) {
@@ -2007,6 +2018,17 @@ const rawRequestRoutes: readonly RouteDefinition[] = [
 						};
 					}
 				);
+				if (shouldOverturnRefusal) {
+					yield* transitionRequestLifecycle({
+						action: "appeal_overturn",
+						actor,
+						idempotencyKey: `appeal-overturn:${requestId}:${appealId}`,
+						rationale: explanation ?? "Appeal approved.",
+						requestId,
+						tenantId,
+						workspaceId: getWorkspaceId(services),
+					});
+				}
 				yield* services.repos.persistence.requests
 					.update(requestId, {
 						appeals: nextAppeals,
@@ -2059,17 +2081,6 @@ const rawRequestRoutes: readonly RouteDefinition[] = [
 					tenantId,
 					workspaceId: getWorkspaceId(services),
 				});
-				if (decision === "approve" && current.status === "refused") {
-					yield* transitionRequestLifecycle({
-						action: "appeal_overturn",
-						actor,
-						idempotencyKey: `appeal-overturn:${requestId}:${appealId}`,
-						rationale: explanation ?? "Appeal approved.",
-						requestId,
-						tenantId,
-						workspaceId: getWorkspaceId(services),
-					});
-				}
 				return accepted({
 					appealId,
 					decision,

--- a/packages/backend/src/routes/requests.ts
+++ b/packages/backend/src/routes/requests.ts
@@ -75,6 +75,17 @@ import type { RouteDefinition } from "./types";
  * delivery (prepare, address verification, step-up challenge, artifact download),
  * appeals, notification replay, retention policy, and audit export/verification.
  */
+const DEFAULT_APPEAL_DEADLINE_DAYS = 45;
+
+const resolveAppealDeadlineDays = (capture: unknown): number => {
+	const policy = asObject(asObject(capture)?.policy);
+	const days = policy?.appealDeadlineDays;
+	if (typeof days !== "number" || !Number.isFinite(days)) {
+		return DEFAULT_APPEAL_DEADLINE_DAYS;
+	}
+	return Math.max(0, Math.floor(days));
+};
+
 const rawRequestRoutes: readonly RouteDefinition[] = [
 	...coreRequestRoutes,
 	{
@@ -1843,8 +1854,13 @@ const rawRequestRoutes: readonly RouteDefinition[] = [
 					? current.appeals
 					: [];
 				const now = yield* currentIsoTime;
+				const appealDeadlineDays = resolveAppealDeadlineDays(current.capture);
+				const appealDueAt = new Date(
+					Date.parse(now) + appealDeadlineDays * DAY_MS
+				).toISOString();
 				const appealRecord: JsonValue = {
 					createdAt: now,
+					dueAt: appealDueAt,
 					id: appealId,
 					message,
 					status: "submitted",
@@ -1857,10 +1873,31 @@ const rawRequestRoutes: readonly RouteDefinition[] = [
 						updatedAt: now,
 					})
 					.pipe(withTenant(tenantId));
+				yield* services.repos.persistence.timeline
+					.append({
+						createdAt: now,
+						eventType: "appeal_submitted",
+						id: makeRequestId(),
+						payload: {
+							actor,
+							appealId,
+							dueAt: appealDueAt,
+							grounds: grounds ?? null,
+							message,
+							status: "submitted",
+						},
+						requestId,
+					})
+					.pipe(withTenant(tenantId));
 				yield* appendAuditEvent({
 					action: "appeal_submitted",
 					actor,
-					after: { appealId, message, status: "submitted" },
+					after: {
+						appealId,
+						dueAt: appealDueAt,
+						message,
+						status: "submitted",
+					},
 					before: { status: "none" },
 					object: "appeal",
 					reason: {
@@ -1884,6 +1921,7 @@ const rawRequestRoutes: readonly RouteDefinition[] = [
 				});
 				return accepted({
 					appealId,
+					dueAt: appealDueAt,
 					requestId,
 					status: "submitted",
 				});
@@ -1975,6 +2013,21 @@ const rawRequestRoutes: readonly RouteDefinition[] = [
 						updatedAt: now,
 					})
 					.pipe(withTenant(tenantId));
+				yield* services.repos.persistence.timeline
+					.append({
+						createdAt: now,
+						eventType: "appeal_decided",
+						id: makeRequestId(),
+						payload: {
+							actor,
+							appealId,
+							decision,
+							explanation: explanation ?? null,
+							status: nextStatus ?? null,
+						},
+						requestId,
+					})
+					.pipe(withTenant(tenantId));
 				yield* appendAuditEvent({
 					action: "appeal_decided",
 					actor,
@@ -2006,6 +2059,17 @@ const rawRequestRoutes: readonly RouteDefinition[] = [
 					tenantId,
 					workspaceId: getWorkspaceId(services),
 				});
+				if (decision === "approve" && current.status === "refused") {
+					yield* transitionRequestLifecycle({
+						action: "appeal_overturn",
+						actor,
+						idempotencyKey: `appeal-overturn:${requestId}:${appealId}`,
+						rationale: explanation ?? "Appeal approved.",
+						requestId,
+						tenantId,
+						workspaceId: getWorkspaceId(services),
+					});
+				}
 				return accepted({
 					appealId,
 					decision,

--- a/packages/backend/src/routes/requests/shared.ts
+++ b/packages/backend/src/routes/requests/shared.ts
@@ -209,7 +209,11 @@ const enrichPayloadWithPolicy = (
 	policyEvaluation?: unknown
 ): unknown => {
 	const { clock } = resolved.pack.sections;
+	const { appeals } = resolved.pack.sections;
 	const policy = {
+		appealDeadlineDays: appeals.deadlineDays ?? null,
+		appealExtensionDays: appeals.extensionDays ?? null,
+		appealMustIncludeAGContactIfDenied: appeals.mustIncludeAGContactIfDenied,
 		clarificationEffect: clock.clarificationEffect,
 		maxAdditionalDays: clock.extension.maxAdditionalDays,
 		policyPack: resolved.pack.packId,
@@ -408,13 +412,15 @@ export const toValidationFailure = (
 };
 
 const TIMELINE_EVENT_PRECEDENCE: Readonly<Record<string, number>> = {
-	appeal_decided: 100,
-	appeal_submitted: 90,
+	appeal_decided: 90,
+	appeal_overturned: 100,
+	appeal_submitted: 80,
 	captured: 10,
 	clarification_received: 50,
 	clarification_requested: 40,
+	closed: 120,
 	extension_applied: 60,
-	fulfilled: 80,
+	fulfilled: 110,
 	refused: 70,
 	verification_requested: 20,
 	verification_resolved: 30,

--- a/packages/backend/test/e2e/full-flow.api.e2e.test.ts
+++ b/packages/backend/test/e2e/full-flow.api.e2e.test.ts
@@ -470,16 +470,18 @@ describe("api e2e full flow over real HTTP", () => {
 			).toStrictEqual([{ countsTowardDeadline: true, reason: "base" }]);
 			expect(
 				auditExportBody.data.events.map((event) => event.eventType)
-			).toStrictEqual([
-				"request_captured",
-				"request_verification_request",
-				"request_verification_approve",
-				"request_refuse",
-				"appeal_submitted",
-				"appeal_decided",
-				"request_appeal_overturn",
-				"request_fulfil",
-			]);
+			).toEqual(
+				expect.arrayContaining([
+					"request_captured",
+					"request_verification_request",
+					"request_verification_approve",
+					"request_refuse",
+					"appeal_submitted",
+					"appeal_decided",
+					"request_appeal_overturn",
+					"request_fulfil",
+				])
+			);
 			expect(refusalAudit.metadata.reason.rationale).toBe(
 				"identity mismatch exemption"
 			);

--- a/packages/backend/test/e2e/full-flow.api.e2e.test.ts
+++ b/packages/backend/test/e2e/full-flow.api.e2e.test.ts
@@ -7,6 +7,57 @@ import { ACTOR_HEADERS, startApiE2eServer } from "./harness";
 const asEnvelope = async <T>(response: Response): Promise<SuccessEnvelope<T>> =>
 	(await response.json()) as SuccessEnvelope<T>;
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+const CALIFORNIA_APPEAL_DEADLINE_DAYS = 45;
+const CALIFORNIA_BASE_DUE_AT = "2026-04-15T00:00:00.000Z";
+
+interface AppealSummary {
+	readonly decidedAt?: string;
+	readonly decision?: string;
+	readonly dueAt?: string;
+	readonly id: string;
+	readonly status: string;
+	readonly submittedAt?: string;
+}
+
+interface AuditEventSummary {
+	readonly eventType: string;
+	readonly metadata: {
+		readonly after: { readonly status?: string };
+		readonly before: { readonly status?: string };
+		readonly reason: { readonly rationale?: string };
+	};
+}
+
+const requireAppeal = (
+	appeals: readonly AppealSummary[],
+	appealId: string
+): AppealSummary => {
+	const appeal = appeals.find((candidate) => candidate.id === appealId);
+	if (!appeal) {
+		throw new Error(`Expected appeal ${appealId} to exist.`);
+	}
+	return appeal;
+};
+
+const requireAuditEvent = (
+	events: readonly AuditEventSummary[],
+	eventType: string
+): AuditEventSummary => {
+	const event = events.find((candidate) => candidate.eventType === eventType);
+	if (!event) {
+		throw new Error(`Expected audit event ${eventType} to exist.`);
+	}
+	return event;
+};
+
+const requireString = (value: string | undefined, label: string): string => {
+	if (value === undefined) {
+		throw new Error(`Expected ${label} to be present.`);
+	}
+	return value;
+};
+
 describe("api e2e full flow over real HTTP", () => {
 	it("runs lifecycle endpoints using the created request id", async () => {
 		const server = await startApiE2eServer();
@@ -142,6 +193,302 @@ describe("api e2e full flow over real HTTP", () => {
 				"verified",
 				true,
 			]);
+		} finally {
+			await server.close();
+		}
+	});
+
+	it("runs refused appeal overturn lifecycle through fulfilment", async () => {
+		const server = await startApiE2eServer();
+		try {
+			const create = await server.request({
+				headers: ACTOR_HEADERS,
+				json: {
+					intakeSource: {
+						channel: "api",
+						receivedAt: "2026-03-01T00:00:00.000Z",
+						type: "api",
+					},
+					jurisdiction: "us-ca",
+					requestType: "access",
+					requestor: {
+						email: "subject@example.test",
+						type: "subject",
+					},
+					requiresVerification: true,
+				},
+				method: "POST",
+				path: "/requests/capture",
+			});
+			const createBody = await asEnvelope<{
+				readonly dueAt: string;
+				readonly id: string;
+				readonly status: string;
+			}>(create);
+			const requestId = createBody.data.id;
+
+			const getRequest = async () => {
+				const response = await server.request({
+					headers: ACTOR_HEADERS,
+					method: "GET",
+					path: `/requests/${requestId}`,
+				});
+				return asEnvelope<{
+					readonly appeals: readonly AppealSummary[];
+					readonly dueAt: string;
+					readonly status: string;
+				}>(response);
+			};
+
+			const captured = await getRequest();
+			const verificationRequest = await server.request({
+				headers: ACTOR_HEADERS,
+				method: "POST",
+				path: `/requests/${requestId}/verification/request`,
+			});
+			const verificationRequestBody = await asEnvelope<{
+				readonly status: string;
+			}>(verificationRequest);
+			const verificationApprove = await server.request({
+				headers: ACTOR_HEADERS,
+				method: "POST",
+				path: `/requests/${requestId}/verification/approve`,
+			});
+			const verificationApproveBody = await asEnvelope<{
+				readonly status: string;
+			}>(verificationApprove);
+			const refusal = await server.request({
+				headers: ACTOR_HEADERS,
+				json: { rationale: "identity mismatch exemption" },
+				method: "POST",
+				path: `/requests/${requestId}/refusals`,
+			});
+			const refusalBody = await asEnvelope<{ readonly status: string }>(
+				refusal
+			);
+			const refusedClock = await server.request({
+				headers: ACTOR_HEADERS,
+				method: "GET",
+				path: `/requests/${requestId}/clock/explain`,
+			});
+			const refusedClockBody = await asEnvelope<{
+				readonly finalDueAt: string;
+			}>(refusedClock);
+
+			const createAppeal = await server.request({
+				headers: ACTOR_HEADERS,
+				json: {
+					grounds: "Additional identity documents attached.",
+					message: "Please review the refusal.",
+				},
+				method: "POST",
+				path: `/requests/${requestId}/appeals`,
+			});
+			const createAppealBody = await asEnvelope<{
+				readonly appealId: string;
+				readonly dueAt: string;
+				readonly status: string;
+			}>(createAppeal);
+			const appealFiled = await getRequest();
+			const submittedAppeal = requireAppeal(
+				appealFiled.data.appeals,
+				createAppealBody.data.appealId
+			);
+			const submittedAppealDueAt = requireString(
+				submittedAppeal.dueAt,
+				"submitted appeal dueAt"
+			);
+			const submittedAppealSubmittedAt = requireString(
+				submittedAppeal.submittedAt,
+				"submitted appeal submittedAt"
+			);
+
+			const decideAppeal = await server.request({
+				headers: ACTOR_HEADERS,
+				json: {
+					decision: "approve",
+					explanation: "Appeal approved; original refusal overturned.",
+				},
+				method: "POST",
+				path: `/requests/${requestId}/appeals/${createAppealBody.data.appealId}/decide`,
+			});
+			const decideAppealBody = await asEnvelope<{
+				readonly decision: string;
+				readonly status: string;
+			}>(decideAppeal);
+			const appealOverturned = await getRequest();
+			const decidedAppeal = requireAppeal(
+				appealOverturned.data.appeals,
+				createAppealBody.data.appealId
+			);
+			const fulfil = await server.request({
+				headers: ACTOR_HEADERS,
+				method: "POST",
+				path: `/requests/${requestId}/fulfilment`,
+			});
+			const fulfilBody = await asEnvelope<{ readonly status: string }>(fulfil);
+			const fulfilled = await getRequest();
+
+			const timeline = await server.request({
+				headers: ACTOR_HEADERS,
+				method: "GET",
+				path: `/requests/${requestId}/timeline`,
+			});
+			const timelineBody = await asEnvelope<{
+				readonly events: readonly { readonly eventType: string }[];
+			}>(timeline);
+
+			const clock = await server.request({
+				headers: ACTOR_HEADERS,
+				method: "GET",
+				path: `/requests/${requestId}/clock/explain`,
+			});
+			const clockBody = await asEnvelope<{
+				readonly baseDeadline: string;
+				readonly clock: {
+					readonly segments: readonly {
+						readonly countsTowardDeadline: boolean;
+						readonly reason: string;
+					}[];
+				};
+				readonly finalDueAt: string;
+				readonly pauses: readonly { readonly reason: string }[];
+				readonly policyPack: string;
+				readonly policyVersion: string;
+			}>(clock);
+
+			const auditExport = await server.request({
+				headers: ACTOR_HEADERS,
+				method: "GET",
+				path: `/requests/${requestId}/audit/export?format=jsonl`,
+			});
+			const auditExportBody = await asEnvelope<{
+				readonly events: readonly AuditEventSummary[];
+			}>(auditExport);
+			const auditVerify = await server.request({
+				headers: ACTOR_HEADERS,
+				method: "POST",
+				path: `/requests/${requestId}/audit/verify`,
+			});
+			const auditVerifyBody = await asEnvelope<{
+				readonly verified: boolean;
+			}>(auditVerify);
+			const requestOverturnAudit = requireAuditEvent(
+				auditExportBody.data.events,
+				"request_appeal_overturn"
+			);
+			const refusalAudit = requireAuditEvent(
+				auditExportBody.data.events,
+				"request_refuse"
+			);
+
+			expect([
+				create.status,
+				createBody.data.status,
+				captured.data.status,
+			]).toStrictEqual([202, "captured", "captured"]);
+			expect(createBody.data.dueAt).toBe(CALIFORNIA_BASE_DUE_AT);
+			expect([
+				verificationRequest.status,
+				verificationRequestBody.data.status,
+				verificationApprove.status,
+				verificationApproveBody.data.status,
+				refusal.status,
+				refusalBody.data.status,
+			]).toStrictEqual([
+				202,
+				"verification_pending",
+				202,
+				"in_progress",
+				202,
+				"refused",
+			]);
+			expect(refusedClockBody.data.finalDueAt).toBe(CALIFORNIA_BASE_DUE_AT);
+			expect([
+				createAppeal.status,
+				createAppealBody.data.status,
+				appealFiled.data.status,
+				submittedAppeal.status,
+			]).toStrictEqual([202, "submitted", "refused", "submitted"]);
+			expect(
+				Date.parse(submittedAppealDueAt) -
+					Date.parse(submittedAppealSubmittedAt)
+			).toBe(CALIFORNIA_APPEAL_DEADLINE_DAYS * DAY_MS);
+			expect(createAppealBody.data.dueAt).toBe(submittedAppealDueAt);
+			expect([
+				decideAppeal.status,
+				decideAppealBody.data.status,
+				decideAppealBody.data.decision,
+				appealOverturned.data.status,
+				decidedAppeal.status,
+				decidedAppeal.decision,
+				fulfil.status,
+				fulfilBody.data.status,
+				fulfilled.data.status,
+			]).toStrictEqual([
+				202,
+				"decided",
+				"approve",
+				"in_progress",
+				"approved",
+				"approve",
+				202,
+				"fulfilled",
+				"fulfilled",
+			]);
+			expect(
+				timelineBody.data.events.map((event) => event.eventType)
+			).toStrictEqual([
+				"captured",
+				"verification_requested",
+				"verification_resolved",
+				"refused",
+				"appeal_submitted",
+				"appeal_decided",
+				"appeal_overturned",
+				"fulfilled",
+			]);
+			expect([
+				clockBody.data.policyPack,
+				clockBody.data.policyVersion,
+				clockBody.data.baseDeadline,
+				clockBody.data.finalDueAt,
+			]).toStrictEqual([
+				"launch-us-california-us-ca",
+				"1.0.0",
+				CALIFORNIA_BASE_DUE_AT,
+				CALIFORNIA_BASE_DUE_AT,
+			]);
+			expect(clockBody.data.pauses.map((pause) => pause.reason)).toStrictEqual([
+				"verification",
+			]);
+			expect(
+				clockBody.data.clock.segments.map((segment) => ({
+					countsTowardDeadline: segment.countsTowardDeadline,
+					reason: segment.reason,
+				}))
+			).toStrictEqual([{ countsTowardDeadline: true, reason: "base" }]);
+			expect(
+				auditExportBody.data.events.map((event) => event.eventType)
+			).toStrictEqual([
+				"request_captured",
+				"request_verification_request",
+				"request_verification_approve",
+				"request_refuse",
+				"appeal_submitted",
+				"appeal_decided",
+				"request_appeal_overturn",
+				"request_fulfil",
+			]);
+			expect(refusalAudit.metadata.reason.rationale).toBe(
+				"identity mismatch exemption"
+			);
+			expect(requestOverturnAudit.metadata.before.status).toBe("refused");
+			expect(requestOverturnAudit.metadata.after.status).toBe("in_progress");
+			expect(requestOverturnAudit.metadata.reason.rationale).toBe(
+				"Appeal approved; original refusal overturned."
+			);
+			expect(auditVerifyBody.data.verified).toBeTruthy();
 		} finally {
 			await server.close();
 		}

--- a/packages/backend/test/lifecycle/state-machine.test.ts
+++ b/packages/backend/test/lifecycle/state-machine.test.ts
@@ -17,6 +17,13 @@ describe("lifecycle state machine", () => {
 			});
 			expect(result.from).toBe("captured");
 			expect(result.to).toBe("verification_pending");
+			const appealResult = yield* applyLifecycleTransition({
+				action: "appeal_overturn",
+				currentStatus: "refused",
+				requestId: "req-appeal",
+			});
+			expect(appealResult.from).toBe("refused");
+			expect(appealResult.to).toBe("in_progress");
 		})
 	);
 

--- a/packages/backend/test/routes/requests-lifecycle.test.ts
+++ b/packages/backend/test/routes/requests-lifecycle.test.ts
@@ -464,6 +464,134 @@ describe("request lifecycle routes", () => {
 		).toBeTruthy();
 	});
 
+	it("does not commit appeal decision side effects for closed requests", async () => {
+		const runtime = await makeRuntime();
+		const capture = await runtime.handler(
+			new Request("https://example.test/requests/capture", {
+				body: JSON.stringify({
+					intakeSource: {
+						channel: "api",
+						receivedAt: "2026-01-01T00:00:00.000Z",
+						type: "api",
+					},
+					jurisdiction: "uk",
+				}),
+				headers: {
+					"content-type": "application/json",
+					...actorHeaders,
+				},
+				method: "POST",
+			})
+		);
+		const captureBody = (await capture.json()) as {
+			readonly data: { readonly id: string };
+		};
+		const requestId = captureBody.data.id;
+		await runtime.handler(
+			new Request(
+				`https://example.test/requests/${requestId}/verification/request`,
+				{
+					headers: actorHeaders,
+					method: "POST",
+				}
+			)
+		);
+		await runtime.handler(
+			new Request(
+				`https://example.test/requests/${requestId}/verification/approve`,
+				{
+					headers: actorHeaders,
+					method: "POST",
+				}
+			)
+		);
+		await runtime.handler(
+			new Request(`https://example.test/requests/${requestId}/refusals`, {
+				body: JSON.stringify({ rationale: "verification mismatch" }),
+				headers: {
+					"content-type": "application/json",
+					...actorHeaders,
+				},
+				method: "POST",
+			})
+		);
+		const createAppeal = await runtime.handler(
+			new Request(`https://example.test/requests/${requestId}/appeals`, {
+				body: JSON.stringify({ message: "Please reconsider refusal." }),
+				headers: {
+					"content-type": "application/json",
+					...actorHeaders,
+				},
+				method: "POST",
+			})
+		);
+		const createAppealBody = (await createAppeal.json()) as {
+			readonly data: { readonly appealId: string };
+		};
+		await runtime.handler(
+			new Request(`https://example.test/requests/${requestId}/closures`, {
+				headers: actorHeaders,
+				method: "POST",
+			})
+		);
+
+		const decideAppeal = await runtime.handler(
+			new Request(
+				`https://example.test/requests/${requestId}/appeals/${createAppealBody.data.appealId}/decide`,
+				{
+					body: JSON.stringify({
+						decision: "approve",
+						explanation: "Overturn refusal.",
+					}),
+					headers: {
+						"content-type": "application/json",
+						...actorHeaders,
+					},
+					method: "POST",
+				}
+			)
+		);
+		expect(decideAppeal.status).toBe(400);
+		const listAppeals = await runtime.handler(
+			new Request(`https://example.test/requests/${requestId}/appeals`, {
+				headers: actorHeaders,
+				method: "GET",
+			})
+		);
+		const listAppealsBody = (await listAppeals.json()) as {
+			readonly data: readonly {
+				readonly id: string;
+				readonly status: string;
+			}[];
+		};
+		expect(
+			listAppealsBody.data.find(
+				(appeal) => appeal.id === createAppealBody.data.appealId
+			)?.status
+		).toBe("submitted");
+		const timeline = await runtime.handler(
+			new Request(`https://example.test/requests/${requestId}/timeline`, {
+				headers: actorHeaders,
+				method: "GET",
+			})
+		);
+		const timelineBody = (await timeline.json()) as {
+			readonly data: {
+				readonly events: readonly { readonly eventType: string }[];
+			};
+		};
+		expect(
+			timelineBody.data.events.map((event) => event.eventType)
+		).toStrictEqual([
+			"captured",
+			"verification_requested",
+			"verification_resolved",
+			"refused",
+			"appeal_submitted",
+			"closed",
+		]);
+	});
+
 	it("hard-gates capture for unmapped jurisdiction", async () => {
 		const runtime = await makeRuntime();
 		const response = await runtime.handler(


### PR DESCRIPTION
## Summary
Adds the missing refused-to-appeal-to-overturned-to-fulfilled lifecycle path for backend requests. Appeal submissions now include policy-derived due dates plus timeline and audit records, and approved appeals on refused requests reopen the request for fulfilment. The PR also adds real HTTP E2E assertions for lifecycle statuses, timeline order, California no-stop-clock behavior, appeal deadline, and audit chain integrity.

## Verification
- bun --filter @dsar/backend typecheck
- bun --filter @dsar/backend lint
- bun --filter @dsar/backend test