### PR TITLE
[persistence] Add migration conformance coverage

### DIFF
--- a/packages/internals/persistence/src/migrations/0001-initial.ts
+++ b/packages/internals/persistence/src/migrations/0001-initial.ts
@@ -234,3 +234,44 @@ export const applyMigration0001 = (
 		yield* sql`CREATE INDEX IF NOT EXISTS idx_chat_locks_tenant_expiry
 			ON chat_thread_locks(tenant_id, expires_at)`;
 	});
+
+/**
+ * Test-only rollback for the initial schema migration.
+ *
+ * Production persistence remains forward-only; this helper exists so driver
+ * migration suites can verify each migration's DDL boundary.
+ *
+ * @param sql - Effect SQL client used to execute rollback DDL.
+ * @returns An effect that succeeds once the migration-owned objects are gone.
+ */
+export const revertMigration0001 = (
+	sql: SqlClient.SqlClient
+): Effect.Effect<void, SqlError> =>
+	Effect.gen(function* revertMigration0001Program() {
+		yield* sql`DROP INDEX IF EXISTS idx_chat_locks_tenant_expiry`;
+		yield* sql`DROP INDEX IF EXISTS idx_chat_state_tenant_expiry`;
+		yield* sql`DROP INDEX IF EXISTS idx_notification_attempts_tenant_event`;
+		yield* sql`DROP INDEX IF EXISTS idx_notification_events_tenant_idempotency`;
+		yield* sql`DROP INDEX IF EXISTS idx_notification_events_tenant_request`;
+		yield* sql`DROP INDEX IF EXISTS idx_audit_tenant_request`;
+		yield* sql`DROP INDEX IF EXISTS idx_timeline_tenant_request`;
+		yield* sql`DROP INDEX IF EXISTS idx_requests_tenant_policy_created`;
+		yield* sql`DROP INDEX IF EXISTS idx_requests_tenant_requestor_email_created`;
+		yield* sql`DROP INDEX IF EXISTS idx_requests_tenant_subject_external_created`;
+		yield* sql`DROP INDEX IF EXISTS idx_requests_tenant_subject_created`;
+		yield* sql`DROP INDEX IF EXISTS idx_requests_tenant_due`;
+
+		yield* sql`DROP TABLE IF EXISTS chat_thread_locks`;
+		yield* sql`DROP TABLE IF EXISTS chat_thread_subscriptions`;
+		yield* sql`DROP TABLE IF EXISTS chat_state_entries`;
+		yield* sql`DROP TABLE IF EXISTS notification_delivery_attempts`;
+		yield* sql`DROP TABLE IF EXISTS notification_events`;
+		yield* sql`DROP TABLE IF EXISTS audit_events`;
+		yield* sql`DROP TABLE IF EXISTS retention_policies`;
+		yield* sql`DROP TABLE IF EXISTS fulfillment_artifacts`;
+		yield* sql`DROP TABLE IF EXISTS verification_evidence`;
+		yield* sql`DROP TABLE IF EXISTS policy_assignments`;
+		yield* sql`DROP TABLE IF EXISTS request_timeline_events`;
+		yield* sql`DROP TABLE IF EXISTS request_clock_segments`;
+		yield* sql`DROP TABLE IF EXISTS requests`;
+	});

--- a/packages/internals/persistence/src/migrations/0002-webhook-endpoints.ts
+++ b/packages/internals/persistence/src/migrations/0002-webhook-endpoints.ts
@@ -55,3 +55,22 @@ export const applyMigration0002 = (
 			ON webhook_signing_keys(tenant_id, endpoint_id)
 			WHERE role = 'primary'`;
 	});
+
+/**
+ * Test-only rollback for webhook endpoint DDL.
+ *
+ * Production persistence remains forward-only; this helper exists so driver
+ * migration suites can verify each migration's DDL boundary.
+ *
+ * @param sql - Effect SQL client used to execute rollback DDL.
+ * @returns An effect that succeeds once webhook objects are gone.
+ */
+export const revertMigration0002 = (
+	sql: SqlClient.SqlClient
+): Effect.Effect<void, SqlError> =>
+	Effect.gen(function* revertMigration0002Program() {
+		yield* sql`DROP INDEX IF EXISTS idx_webhook_keys_primary`;
+		yield* sql`DROP INDEX IF EXISTS idx_webhook_keys_tenant_endpoint`;
+		yield* sql`DROP TABLE IF EXISTS webhook_signing_keys`;
+		yield* sql`DROP TABLE IF EXISTS webhook_endpoints`;
+	});

--- a/packages/internals/persistence/src/services/persistence/migrations.ts
+++ b/packages/internals/persistence/src/services/persistence/migrations.ts
@@ -1,251 +1,177 @@
 import * as Effect from "effect/Effect";
+import type { SqlError } from "effect/unstable/sql/SqlError";
 
 import {
-	backfillRequestLookupColumns,
-	ensureRequestLookupColumns,
-} from "./request-lookup-migrations";
+	applyMigration0001,
+	migrationId as migration0001Id,
+	migrationName as migration0001Name,
+	revertMigration0001,
+} from "../../migrations/0001-initial";
+import {
+	applyMigration0002,
+	migrationId as migration0002Id,
+	migrationName as migration0002Name,
+	revertMigration0002,
+} from "../../migrations/0002-webhook-endpoints";
 import type { Sql } from "./shared";
 
 /**
- * Creates all persistence tables and indexes if they do not already exist.
+ * Metadata table used to record successfully applied schema migrations.
+ */
+export const MIGRATION_TABLE_NAME = "dsar_schema_migrations";
+
+/**
+ * Internal migration descriptor used by the runner and driver conformance
+ * tests. Rollback is intentionally not exposed through the package entrypoint.
+ */
+export interface PersistenceMigration {
+	/** Monotonic migration identifier. */
+	readonly id: number;
+	/** Human-readable migration name recorded in metadata. */
+	readonly name: string;
+	/** Applies the migration. */
+	readonly up: (sql: Sql) => Effect.Effect<void, SqlError>;
+	/** Reverts only objects owned by this migration for test coverage. */
+	readonly down: (sql: Sql) => Effect.Effect<void, SqlError>;
+}
+
+interface AppliedMigrationRow {
+	readonly id: number;
+	readonly name: string;
+}
+
+const migrations = [
+	{
+		down: revertMigration0001,
+		id: migration0001Id,
+		name: migration0001Name,
+		up: applyMigration0001,
+	},
+	{
+		down: revertMigration0002,
+		id: migration0002Id,
+		name: migration0002Name,
+		up: applyMigration0002,
+	},
+] as const satisfies readonly PersistenceMigration[];
+
+const migrationById: ReadonlyMap<number, PersistenceMigration> = new Map(
+	migrations.map((migration) => [migration.id, migration])
+);
+
+const ensureMigrationMetadataTable = (sql: Sql) =>
+	sql`CREATE TABLE IF NOT EXISTS dsar_schema_migrations (
+		id INTEGER NOT NULL PRIMARY KEY,
+		name TEXT NOT NULL,
+		applied_at TEXT NOT NULL
+	)`;
+
+const readAppliedMigrations = (
+	sql: Sql
+): Effect.Effect<readonly AppliedMigrationRow[], SqlError> =>
+	sql<AppliedMigrationRow>`SELECT id, name
+		FROM dsar_schema_migrations
+		ORDER BY id`;
+
+const assertAppliedMigrationsMatchRegistry = (
+	rows: readonly AppliedMigrationRow[]
+) =>
+	Effect.gen(function* assertAppliedMigrationsMatchRegistryProgram() {
+		const appliedIds = new Set(rows.map((row) => Number(row.id)));
+		for (const row of rows) {
+			const migrationId = Number(row.id);
+			const migration = migrationById.get(migrationId);
+			if (!migration) {
+				return yield* Effect.fail(
+					new Error(
+						`Database contains unknown DSAR schema migration ${row.id}.`
+					)
+				);
+			}
+			if (migration.name !== row.name) {
+				return yield* Effect.fail(
+					new Error(
+						`Database migration ${row.id} is named "${row.name}", expected "${migration.name}".`
+					)
+				);
+			}
+		}
+		let foundMissingMigration = false;
+		for (const migration of migrations) {
+			if (!appliedIds.has(migration.id)) {
+				foundMissingMigration = true;
+				continue;
+			}
+			if (foundMissingMigration) {
+				return yield* Effect.fail(
+					new Error(
+						`Database has migration ${migration.id} recorded without all prior DSAR schema migrations.`
+					)
+				);
+			}
+		}
+	});
+
+const recordAppliedMigration = (sql: Sql, migration: PersistenceMigration) =>
+	sql`INSERT INTO dsar_schema_migrations (id, name, applied_at)
+		VALUES (${migration.id}, ${migration.name}, CURRENT_TIMESTAMP)`;
+
+/**
+ * Ordered migration registry used by driver conformance tests.
  *
- * @param sql - SQL client connection used to execute the DDL statements.
- * @returns An effect that completes once every table and index has been
- *   created, failing on SQL errors.
+ * @returns Registered migrations in application order.
+ */
+export const getPersistenceMigrationsForTest =
+	(): readonly PersistenceMigration[] => migrations;
+
+/**
+ * Reads applied migration metadata for driver conformance tests.
+ *
+ * @param sql - Effect SQL client used to query metadata.
+ * @returns Applied migration rows ordered by migration id.
+ */
+export const readAppliedMigrationsForTest = readAppliedMigrations;
+
+/**
+ * Creates the migration metadata table for driver conformance tests that build
+ * historical database states directly.
+ *
+ * @param sql - Effect SQL client used to create metadata.
+ * @returns An effect that succeeds when the table exists.
+ */
+export const ensureMigrationMetadataTableForTest = ensureMigrationMetadataTable;
+
+/**
+ * Records an applied migration for driver conformance tests.
+ *
+ * @param sql - Effect SQL client used to write metadata.
+ * @param migration - Migration descriptor to record.
+ * @returns An effect that succeeds when metadata is written.
+ */
+export const recordAppliedMigrationForTest = recordAppliedMigration;
+
+/**
+ * Applies all unapplied persistence migrations in registry order.
+ *
+ * @param sql - SQL client connection used to execute DDL and metadata writes.
+ * @returns An effect that completes once the schema is current.
  */
 export const runMigrations = (sql: Sql) =>
 	Effect.gen(function* runMigrationsProgram() {
-		yield* sql`CREATE TABLE IF NOT EXISTS requests (
-			id TEXT NOT NULL,
-			tenant_id TEXT NOT NULL,
-			status TEXT NOT NULL,
-			received_at TEXT NOT NULL,
-			due_at TEXT NOT NULL,
-			clock_mode TEXT NOT NULL,
-			subject_id TEXT,
-			subject_external_ref TEXT,
-			requestor_email TEXT,
-			policy_pack TEXT,
-			requestor_json TEXT NOT NULL,
-			authority_json TEXT NOT NULL,
-			capture_json TEXT NOT NULL,
-			appeals_json TEXT NOT NULL,
-			created_at TEXT NOT NULL,
-			updated_at TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, id)
-		)`;
-		yield* ensureRequestLookupColumns(sql);
-		yield* backfillRequestLookupColumns(sql);
+		yield* ensureMigrationMetadataTable(sql);
+		const appliedRows = yield* readAppliedMigrations(sql);
+		yield* assertAppliedMigrationsMatchRegistry(appliedRows);
 
-		yield* sql`CREATE TABLE IF NOT EXISTS request_clock_segments (
-			id TEXT NOT NULL,
-			tenant_id TEXT NOT NULL,
-			request_id TEXT NOT NULL,
-			from_at TEXT NOT NULL,
-			to_at TEXT NOT NULL,
-			reason TEXT NOT NULL,
-			counts_toward_deadline INTEGER NOT NULL,
-			policy_version TEXT NOT NULL,
-			actor TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, id),
-			FOREIGN KEY (tenant_id, request_id) REFERENCES requests(tenant_id, id)
-		)`;
-
-		yield* sql`CREATE TABLE IF NOT EXISTS request_timeline_events (
-			id TEXT NOT NULL,
-			tenant_id TEXT NOT NULL,
-			request_id TEXT NOT NULL,
-			event_type TEXT NOT NULL,
-			payload_json TEXT NOT NULL,
-			created_at TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, id),
-			FOREIGN KEY (tenant_id, request_id) REFERENCES requests(tenant_id, id)
-		)`;
-
-		yield* sql`CREATE TABLE IF NOT EXISTS policy_assignments (
-			id TEXT NOT NULL,
-			tenant_id TEXT NOT NULL,
-			request_id TEXT NOT NULL,
-			policy_pack TEXT NOT NULL,
-			policy_version TEXT NOT NULL,
-			assigned_at TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, id),
-			FOREIGN KEY (tenant_id, request_id) REFERENCES requests(tenant_id, id)
-		)`;
-
-		yield* sql`CREATE TABLE IF NOT EXISTS verification_evidence (
-			id TEXT NOT NULL,
-			tenant_id TEXT NOT NULL,
-			request_id TEXT NOT NULL,
-			level TEXT NOT NULL,
-			reason_for_doubt TEXT NOT NULL,
-			methods_allowed_json TEXT NOT NULL,
-			status TEXT NOT NULL,
-			evidence_artifacts_json TEXT NOT NULL,
-			retention_expires_at TEXT NOT NULL,
-			created_at TEXT NOT NULL,
-			updated_at TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, id),
-			FOREIGN KEY (tenant_id, request_id) REFERENCES requests(tenant_id, id)
-		)`;
-
-		yield* sql`CREATE TABLE IF NOT EXISTS fulfillment_artifacts (
-			id TEXT NOT NULL,
-			tenant_id TEXT NOT NULL,
-			request_id TEXT NOT NULL,
-			artifact_manifest_json TEXT NOT NULL,
-			validation_state TEXT NOT NULL,
-			delivery_prepare_json TEXT NOT NULL,
-			delivery_logs_json TEXT NOT NULL,
-			token_gate_json TEXT NOT NULL,
-			created_at TEXT NOT NULL,
-			updated_at TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, id),
-			FOREIGN KEY (tenant_id, request_id) REFERENCES requests(tenant_id, id)
-		)`;
-
-		yield* sql`CREATE TABLE IF NOT EXISTS retention_policies (
-			id TEXT NOT NULL,
-			tenant_id TEXT NOT NULL,
-			class TEXT NOT NULL,
-			min_days INTEGER NOT NULL,
-			max_days INTEGER NOT NULL,
-			purge_enabled INTEGER NOT NULL,
-			legal_hold_enabled INTEGER NOT NULL,
-			updated_at TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, id),
-			UNIQUE (tenant_id, class)
-		)`;
-
-		yield* sql`CREATE TABLE IF NOT EXISTS audit_events (
-			id TEXT NOT NULL,
-			tenant_id TEXT NOT NULL,
-			request_id TEXT,
-			actor TEXT NOT NULL,
-			action TEXT NOT NULL,
-			object TEXT NOT NULL,
-			before_json TEXT NOT NULL,
-			after_json TEXT NOT NULL,
-			reason_json TEXT NOT NULL,
-			prev_hash TEXT,
-			hash TEXT NOT NULL,
-			hash_alg TEXT NOT NULL,
-			sequence INTEGER NOT NULL,
-			created_at TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, id)
-		)`;
-
-		yield* sql`CREATE TABLE IF NOT EXISTS notification_events (
-			id TEXT NOT NULL,
-			tenant_id TEXT NOT NULL,
-			request_id TEXT NOT NULL,
-			event_type TEXT NOT NULL,
-			payload_json TEXT NOT NULL,
-			correlation_id TEXT NOT NULL,
-			idempotency_key TEXT NOT NULL,
-			policy_version TEXT NOT NULL,
-			locale TEXT NOT NULL,
-			created_at TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, id),
-			FOREIGN KEY (tenant_id, request_id) REFERENCES requests(tenant_id, id)
-		)`;
-
-		yield* sql`CREATE TABLE IF NOT EXISTS notification_delivery_attempts (
-			id TEXT NOT NULL,
-			tenant_id TEXT NOT NULL,
-			notification_event_id TEXT NOT NULL,
-			request_id TEXT NOT NULL,
-			channel TEXT NOT NULL,
-			destination TEXT NOT NULL,
-			attempt INTEGER NOT NULL,
-			status TEXT NOT NULL,
-			response_code INTEGER,
-			error_text TEXT,
-			created_at TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, id),
-			FOREIGN KEY (tenant_id, request_id) REFERENCES requests(tenant_id, id)
-		)`;
-
-		yield* sql`CREATE TABLE IF NOT EXISTS webhook_endpoints (
-			id TEXT NOT NULL,
-			tenant_id TEXT NOT NULL,
-			url TEXT NOT NULL,
-			created_at TEXT NOT NULL,
-			updated_at TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, id)
-		)`;
-
-		yield* sql`CREATE TABLE IF NOT EXISTS webhook_signing_keys (
-			id TEXT NOT NULL,
-			tenant_id TEXT NOT NULL,
-			endpoint_id TEXT NOT NULL,
-			secret_ciphertext TEXT NOT NULL,
-			secret_key_id TEXT NOT NULL,
-			secret_nonce TEXT NOT NULL,
-			secret_tag TEXT NOT NULL,
-			secret_encrypted_data_key TEXT NOT NULL,
-			secret_data_key_nonce TEXT NOT NULL,
-			secret_data_key_tag TEXT NOT NULL,
-			role TEXT NOT NULL CHECK (role IN ('primary', 'secondary')),
-			expires_at TEXT,
-			created_at TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, id),
-			FOREIGN KEY (tenant_id, endpoint_id) REFERENCES webhook_endpoints(tenant_id, id)
-		)`;
-
-		yield* sql`CREATE TABLE IF NOT EXISTS chat_state_entries (
-			tenant_id TEXT NOT NULL,
-			cache_key TEXT NOT NULL,
-			value_json TEXT NOT NULL,
-			expires_at TEXT,
-			created_at TEXT NOT NULL,
-			updated_at TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, cache_key)
-		)`;
-
-		yield* sql`CREATE TABLE IF NOT EXISTS chat_thread_subscriptions (
-			tenant_id TEXT NOT NULL,
-			thread_id TEXT NOT NULL,
-			subscribed_at TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, thread_id)
-		)`;
-
-		yield* sql`CREATE TABLE IF NOT EXISTS chat_thread_locks (
-			tenant_id TEXT NOT NULL,
-			thread_id TEXT NOT NULL,
-			token TEXT NOT NULL,
-			expires_at TEXT NOT NULL,
-			acquired_at TEXT NOT NULL,
-			PRIMARY KEY (tenant_id, thread_id)
-		)`;
-
-		yield* sql`CREATE INDEX IF NOT EXISTS idx_requests_tenant_due
-			ON requests(tenant_id, due_at)`;
-		yield* sql`CREATE INDEX IF NOT EXISTS idx_requests_tenant_subject_created
-			ON requests(tenant_id, subject_id, created_at, id)`;
-		yield* sql`CREATE INDEX IF NOT EXISTS idx_requests_tenant_subject_external_created
-			ON requests(tenant_id, subject_external_ref, created_at, id)`;
-		yield* sql`CREATE INDEX IF NOT EXISTS idx_requests_tenant_requestor_email_created
-			ON requests(tenant_id, requestor_email, created_at, id)`;
-		yield* sql`CREATE INDEX IF NOT EXISTS idx_requests_tenant_policy_created
-			ON requests(tenant_id, policy_pack, created_at, id)`;
-		yield* sql`CREATE INDEX IF NOT EXISTS idx_timeline_tenant_request
-			ON request_timeline_events(tenant_id, request_id)`;
-		yield* sql`CREATE INDEX IF NOT EXISTS idx_audit_tenant_request
-			ON audit_events(tenant_id, request_id)`;
-		yield* sql`CREATE INDEX IF NOT EXISTS idx_notification_events_tenant_request
-			ON notification_events(tenant_id, request_id)`;
-		yield* sql`CREATE INDEX IF NOT EXISTS idx_notification_events_tenant_idempotency
-			ON notification_events(tenant_id, idempotency_key)`;
-		yield* sql`CREATE INDEX IF NOT EXISTS idx_notification_attempts_tenant_event
-			ON notification_delivery_attempts(tenant_id, notification_event_id)`;
-		yield* sql`CREATE INDEX IF NOT EXISTS idx_webhook_keys_tenant_endpoint
-			ON webhook_signing_keys(tenant_id, endpoint_id)`;
-		yield* sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_webhook_keys_primary
-			ON webhook_signing_keys(tenant_id, endpoint_id)
-			WHERE role = 'primary'`;
-		yield* sql`CREATE INDEX IF NOT EXISTS idx_chat_state_tenant_expiry
-			ON chat_state_entries(tenant_id, expires_at)`;
-		yield* sql`CREATE INDEX IF NOT EXISTS idx_chat_locks_tenant_expiry
-			ON chat_thread_locks(tenant_id, expires_at)`;
+		const appliedIds = new Set(appliedRows.map((row) => Number(row.id)));
+		for (const migration of migrations) {
+			if (appliedIds.has(migration.id)) {
+				continue;
+			}
+			yield* sql.withTransaction(
+				Effect.gen(function* applyMigrationTransaction() {
+					yield* migration.up(sql);
+					yield* recordAppliedMigration(sql, migration);
+				})
+			);
+		}
 	});

--- a/packages/internals/persistence/src/services/persistence/migrations.ts
+++ b/packages/internals/persistence/src/services/persistence/migrations.ts
@@ -114,7 +114,8 @@ const assertAppliedMigrationsMatchRegistry = (
 
 const recordAppliedMigration = (sql: Sql, migration: PersistenceMigration) =>
 	sql`INSERT INTO dsar_schema_migrations (id, name, applied_at)
-		VALUES (${migration.id}, ${migration.name}, CURRENT_TIMESTAMP)`;
+		VALUES (${migration.id}, ${migration.name}, CURRENT_TIMESTAMP)
+		ON CONFLICT(id) DO NOTHING`;
 
 /**
  * Ordered migration registry used by driver conformance tests.
@@ -174,4 +175,6 @@ export const runMigrations = (sql: Sql) =>
 				})
 			);
 		}
+		const finalAppliedRows = yield* readAppliedMigrations(sql);
+		yield* assertAppliedMigrationsMatchRegistry(finalAppliedRows);
 	});

--- a/packages/internals/persistence/test/migration-conformance.ts
+++ b/packages/internals/persistence/test/migration-conformance.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import {
+	ensureMigrationMetadataTableForTest,
+	getPersistenceMigrationsForTest,
+	readAppliedMigrationsForTest,
+	recordAppliedMigrationForTest,
+	runMigrations,
+} from "../src/services/persistence/migrations";
+import type { Sql } from "../src/services/persistence/shared";
+
+export interface SchemaSnapshot {
+	readonly indexes: readonly string[];
+	readonly tables: readonly string[];
+}
+
+export interface MigrationTestContext {
+	readonly cleanup?: () => Promise<void>;
+	readonly run: <A>(
+		program: (sql: Sql) => Effect.Effect<A, unknown>
+	) => Promise<A>;
+}
+
+export interface MigrationConformanceOptions {
+	readonly inspectSchema: (sql: Sql) => Effect.Effect<SchemaSnapshot, unknown>;
+	readonly makeContext: (
+		label: string
+	) => MigrationTestContext | Promise<MigrationTestContext>;
+	readonly name: string;
+	readonly skip?: boolean;
+}
+
+const migrations = getPersistenceMigrationsForTest();
+const currentMigrationRows = migrations.map((migration) => ({
+	id: migration.id,
+	name: migration.name,
+}));
+
+const withContext = async (
+	options: MigrationConformanceOptions,
+	label: string,
+	testProgram: (context: MigrationTestContext) => Promise<void>
+) => {
+	const context = await options.makeContext(label);
+	try {
+		await testProgram(context);
+	} finally {
+		await context.cleanup?.();
+	}
+};
+
+const seedCurrentRequest = (sql: Sql, requestId: string) =>
+	sql`INSERT INTO requests (
+		id,
+		tenant_id,
+		status,
+		received_at,
+		due_at,
+		clock_mode,
+		subject_id,
+		subject_external_ref,
+		requestor_email,
+		policy_pack,
+		requestor_json,
+		authority_json,
+		capture_json,
+		appeals_json,
+		created_at,
+		updated_at
+	) VALUES (
+		${requestId},
+		'tenant-a',
+		'received',
+		'2026-01-01T00:00:00.000Z',
+		'2026-02-01T00:00:00.000Z',
+		'calendar_days',
+		'subject-current',
+		'external-current',
+		'requestor@example.com',
+		'pack-current',
+		'{"type":"subject","email":"requestor@example.com"}',
+		'{"status":"verified","type":"subject"}',
+		'{"channel":"api","subject":{"subjectId":"subject-current","externalRef":"external-current"},"policy":{"policyPack":"pack-current"}}',
+		'[]',
+		'2026-01-01T00:00:00.000Z',
+		'2026-01-01T00:00:00.000Z'
+	)`;
+
+const seedLegacyRequestTable = (sql: Sql) =>
+	Effect.gen(function* seedLegacyRequestTableProgram() {
+		yield* sql`CREATE TABLE IF NOT EXISTS requests (
+			id TEXT NOT NULL,
+			tenant_id TEXT NOT NULL,
+			status TEXT NOT NULL,
+			received_at TEXT NOT NULL,
+			due_at TEXT NOT NULL,
+			clock_mode TEXT NOT NULL,
+			requestor_json TEXT NOT NULL,
+			authority_json TEXT NOT NULL,
+			capture_json TEXT NOT NULL,
+			appeals_json TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			PRIMARY KEY (tenant_id, id)
+		)`;
+		yield* sql`INSERT INTO requests (
+			id,
+			tenant_id,
+			status,
+			received_at,
+			due_at,
+			clock_mode,
+			requestor_json,
+			authority_json,
+			capture_json,
+			appeals_json,
+			created_at,
+			updated_at
+		) VALUES (
+			'req-legacy',
+			'tenant-a',
+			'received',
+			'2026-01-01T00:00:00.000Z',
+			'2026-02-01T00:00:00.000Z',
+			'calendar_days',
+			'{"type":"subject","email":"legacy@example.com"}',
+			'{}',
+			'{"subject":{"subjectId":"subject-legacy","externalRef":"external-legacy"},"policy":{"policyPack":"pack-legacy"}}',
+			'[]',
+			'2026-01-01T00:00:00.000Z',
+			'2026-01-01T00:00:00.000Z'
+		)`;
+	});
+
+const expectCurrentMigrationMetadata = async (
+	context: MigrationTestContext
+) => {
+	const rows = await context.run((sql) => readAppliedMigrationsForTest(sql));
+	expect(rows).toStrictEqual(currentMigrationRows);
+};
+
+export const defineMigrationConformanceTests = (
+	options: MigrationConformanceOptions
+) => {
+	const describeFn = options.skip ? describe.skip : describe;
+
+	describeFn(`${options.name} migration conformance`, () => {
+		it("applies and records every migration on a clean database", async () => {
+			await withContext(options, "clean", async (context) => {
+				const snapshot = await context.run((sql) =>
+					Effect.gen(function* cleanDatabaseMigrationProgram() {
+						yield* runMigrations(sql);
+						return yield* options.inspectSchema(sql);
+					})
+				);
+
+				await expectCurrentMigrationMetadata(context);
+				expect(snapshot.tables).toEqual(
+					expect.arrayContaining([
+						"dsar_schema_migrations",
+						"requests",
+						"webhook_endpoints",
+						"webhook_signing_keys",
+					])
+				);
+				expect(snapshot.indexes).toEqual(
+					expect.arrayContaining([
+						"idx_requests_tenant_due",
+						"idx_webhook_keys_primary",
+					])
+				);
+			});
+		});
+
+		it.each(migrations)(
+			"applies and rolls back migration $id",
+			async (migration) => {
+				await withContext(
+					options,
+					`up-down-${migration.id}`,
+					async (context) => {
+						const snapshot = await context.run((sql) =>
+							Effect.gen(function* migrationUpDownProgram() {
+								yield* migration.up(sql);
+								const afterUp = yield* options.inspectSchema(sql);
+								yield* migration.down(sql);
+								const afterDown = yield* options.inspectSchema(sql);
+								return { afterDown, afterUp };
+							})
+						);
+
+						if (migration.id === 1) {
+							expect(snapshot.afterUp.tables).toContain("requests");
+							expect(snapshot.afterDown.tables).not.toContain("requests");
+						}
+						if (migration.id === 2) {
+							expect(snapshot.afterUp.tables).toContain("webhook_endpoints");
+							expect(snapshot.afterDown.tables).not.toContain(
+								"webhook_endpoints"
+							);
+						}
+					}
+				);
+			}
+		);
+
+		it("upgrades from the previous migration and preserves rows", async () => {
+			await withContext(options, "from-previous", async (context) => {
+				const requestRows = await context.run((sql) =>
+					Effect.gen(function* upgradeFromPreviousProgram() {
+						yield* ensureMigrationMetadataTableForTest(sql);
+						yield* migrations[0].up(sql);
+						yield* recordAppliedMigrationForTest(sql, migrations[0]);
+						yield* seedCurrentRequest(sql, "req-from-v1");
+						yield* runMigrations(sql);
+						return yield* sql<{ readonly id: string }>`SELECT id
+							FROM requests
+							WHERE tenant_id = 'tenant-a'
+							ORDER BY id`;
+					})
+				);
+
+				await expectCurrentMigrationMetadata(context);
+				expect(requestRows.map((row) => row.id)).toStrictEqual(["req-from-v1"]);
+			});
+		});
+
+		it("backfills legacy request rows while upgrading to current", async () => {
+			await withContext(options, "legacy-backfill", async (context) => {
+				const rows = await context.run((sql) =>
+					Effect.gen(function* legacyBackfillProgram() {
+						yield* seedLegacyRequestTable(sql);
+						yield* runMigrations(sql);
+						return yield* sql<{
+							readonly policy_pack: string | null;
+							readonly requestor_email: string | null;
+							readonly subject_external_ref: string | null;
+							readonly subject_id: string | null;
+						}>`SELECT
+							subject_id,
+							subject_external_ref,
+							requestor_email,
+							policy_pack
+							FROM requests
+							WHERE tenant_id = 'tenant-a' AND id = 'req-legacy'`;
+					})
+				);
+
+				await expectCurrentMigrationMetadata(context);
+				expect(rows).toStrictEqual([
+					{
+						policy_pack: "pack-legacy",
+						requestor_email: "legacy@example.com",
+						subject_external_ref: "external-legacy",
+						subject_id: "subject-legacy",
+					},
+				]);
+			});
+		});
+
+		it("is idempotent when re-run after data exists", async () => {
+			await withContext(options, "idempotent", async (context) => {
+				const result = await context.run((sql) =>
+					Effect.gen(function* idempotentMigrationProgram() {
+						yield* runMigrations(sql);
+						yield* seedCurrentRequest(sql, "req-idempotent");
+						const before = yield* options.inspectSchema(sql);
+						yield* runMigrations(sql);
+						const after = yield* options.inspectSchema(sql);
+						const rows = yield* sql<{
+							readonly capture_json: string;
+							readonly id: string;
+						}>`SELECT id, capture_json
+							FROM requests
+							WHERE tenant_id = 'tenant-a'
+							ORDER BY id`;
+						return { after, before, rows };
+					})
+				);
+
+				await expectCurrentMigrationMetadata(context);
+				expect(result.after).toStrictEqual(result.before);
+				expect(result.rows.map((row) => row.id)).toStrictEqual([
+					"req-idempotent",
+				]);
+				expect(result.rows[0]?.capture_json).toContain("subject-current");
+			});
+		});
+
+		it("fails when recorded migration metadata drifts", async () => {
+			await withContext(options, "metadata-drift", async (context) => {
+				const result = await context.run((sql) =>
+					Effect.gen(function* metadataDriftProgram() {
+						yield* ensureMigrationMetadataTableForTest(sql);
+						yield* sql`INSERT INTO dsar_schema_migrations (id, name, applied_at)
+							VALUES (1, 'wrong_name', CURRENT_TIMESTAMP)`;
+						return yield* Effect.result(runMigrations(sql));
+					})
+				);
+
+				expect(result._tag).toBe("Failure");
+			});
+		});
+
+		it("fails when recorded migration metadata skips a prior migration", async () => {
+			await withContext(options, "metadata-gap", async (context) => {
+				const result = await context.run((sql) =>
+					Effect.gen(function* metadataGapProgram() {
+						yield* ensureMigrationMetadataTableForTest(sql);
+						yield* recordAppliedMigrationForTest(sql, migrations[1]);
+						return yield* Effect.result(runMigrations(sql));
+					})
+				);
+
+				expect(result._tag).toBe("Failure");
+			});
+		});
+	});
+};

--- a/packages/internals/persistence/test/migration-conformance.ts
+++ b/packages/internals/persistence/test/migration-conformance.ts
@@ -288,6 +288,17 @@ export const defineMigrationConformanceTests = (
 			});
 		});
 
+		it("tolerates concurrent migration runners racing metadata inserts", async () => {
+			await withContext(options, "concurrent", async (context) => {
+				const rows = await Promise.all([
+					context.run((sql) => runMigrations(sql)),
+					context.run((sql) => runMigrations(sql)),
+				]).then(() => context.run((sql) => readAppliedMigrationsForTest(sql)));
+
+				expect(rows).toStrictEqual(currentMigrationRows);
+			});
+		});
+
 		it("fails when recorded migration metadata drifts", async () => {
 			await withContext(options, "metadata-drift", async (context) => {
 				const result = await context.run((sql) =>

--- a/packages/persistence-pg/test/migrations.test.ts
+++ b/packages/persistence-pg/test/migrations.test.ts
@@ -1,0 +1,85 @@
+/* oxlint-disable import/no-relative-parent-imports, jest/require-hook */
+
+import { pgDriver } from "@dsar/persistence-pg";
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import type { Sql } from "../../internals/persistence/src/services/persistence/shared";
+import type { MigrationTestContext } from "../../internals/persistence/test/migration-conformance";
+import { defineMigrationConformanceTests } from "../../internals/persistence/test/migration-conformance";
+
+const pgUrl = process.env.DSAR_TEST_PG_URL;
+const hasPgUrl = typeof pgUrl === "string" && pgUrl.length > 0;
+
+const runPgProgram = <A>(
+	url: string,
+	program: (sql: Sql) => Effect.Effect<A, unknown>
+) =>
+	Effect.runPromise(
+		Effect.gen(function* runPgProgramEffect() {
+			const sql = yield* SqlClient.SqlClient;
+			return yield* program(sql);
+		}).pipe(Effect.provide(pgDriver({ url }).layer))
+	);
+
+const quotePgIdentifier = (identifier: string): string =>
+	`"${identifier.replaceAll('"', '""')}"`;
+
+const schemaUrl = (url: string, schemaName: string): string => {
+	const parsedUrl = new URL(url);
+	parsedUrl.searchParams.set("options", `-c search_path=${schemaName}`);
+	return parsedUrl.toString();
+};
+
+const makePgContext = async (label: string): Promise<MigrationTestContext> => {
+	if (!hasPgUrl) {
+		throw new Error("DSAR_TEST_PG_URL is required for pg migration tests.");
+	}
+
+	const schemaName =
+		`dsar_mig_${label.replaceAll(/[^a-z0-9_]/gi, "_")}_${crypto.randomUUID().replaceAll("-", "")}`.slice(
+			0,
+			63
+		);
+	const quotedSchemaName = quotePgIdentifier(schemaName);
+	await runPgProgram(pgUrl, (sql) =>
+		sql.unsafe(`CREATE SCHEMA ${quotedSchemaName}`)
+	);
+
+	const isolatedUrl = schemaUrl(pgUrl, schemaName);
+	return {
+		cleanup: async () => {
+			await runPgProgram(pgUrl, (sql) =>
+				sql.unsafe(`DROP SCHEMA IF EXISTS ${quotedSchemaName} CASCADE`)
+			);
+		},
+		run: (program) => runPgProgram(isolatedUrl, program),
+	};
+};
+
+const inspectPgSchema = (sql: Sql) =>
+	Effect.gen(function* inspectPgSchemaProgram() {
+		const tables = yield* sql<{
+			readonly name: string;
+		}>`SELECT tablename AS name
+			FROM pg_tables
+			WHERE schemaname = current_schema()
+			ORDER BY tablename`;
+		const indexes = yield* sql<{
+			readonly name: string;
+		}>`SELECT indexname AS name
+			FROM pg_indexes
+			WHERE schemaname = current_schema()
+			ORDER BY indexname`;
+		return {
+			indexes: indexes.map((row) => row.name),
+			tables: tables.map((row) => row.name),
+		};
+	});
+
+defineMigrationConformanceTests({
+	inspectSchema: inspectPgSchema,
+	makeContext: makePgContext,
+	name: "pg",
+	skip: !hasPgUrl,
+});

--- a/packages/persistence-pg/test/migrations.test.ts
+++ b/packages/persistence-pg/test/migrations.test.ts
@@ -25,12 +25,6 @@ const runPgProgram = <A>(
 const quotePgIdentifier = (identifier: string): string =>
 	`"${identifier.replaceAll('"', '""')}"`;
 
-const schemaUrl = (url: string, schemaName: string): string => {
-	const parsedUrl = new URL(url);
-	parsedUrl.searchParams.set("options", `-c search_path=${schemaName}`);
-	return parsedUrl.toString();
-};
-
 const makePgContext = async (label: string): Promise<MigrationTestContext> => {
 	if (!hasPgUrl) {
 		throw new Error("DSAR_TEST_PG_URL is required for pg migration tests.");
@@ -46,14 +40,21 @@ const makePgContext = async (label: string): Promise<MigrationTestContext> => {
 		sql.unsafe(`CREATE SCHEMA ${quotedSchemaName}`)
 	);
 
-	const isolatedUrl = schemaUrl(pgUrl, schemaName);
 	return {
 		cleanup: async () => {
 			await runPgProgram(pgUrl, (sql) =>
 				sql.unsafe(`DROP SCHEMA IF EXISTS ${quotedSchemaName} CASCADE`)
 			);
 		},
-		run: (program) => runPgProgram(isolatedUrl, program),
+		run: (program) =>
+			runPgProgram(pgUrl, (sql) =>
+				sql.withTransaction(
+					Effect.gen(function* runInIsolatedSchema() {
+						yield* sql.unsafe(`SET search_path TO ${quotedSchemaName}`);
+						return yield* program(sql);
+					})
+				)
+			),
 	};
 };
 

--- a/packages/persistence-sqlite/test/migrations.test.ts
+++ b/packages/persistence-sqlite/test/migrations.test.ts
@@ -1,0 +1,64 @@
+/* oxlint-disable import/no-relative-parent-imports, jest/require-hook */
+
+import { unlink } from "node:fs/promises";
+
+import { sqliteDriver } from "@dsar/persistence-sqlite";
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import type { Sql } from "../../internals/persistence/src/services/persistence/shared";
+import type { MigrationTestContext } from "../../internals/persistence/test/migration-conformance";
+import { defineMigrationConformanceTests } from "../../internals/persistence/test/migration-conformance";
+
+const sqliteFile = (label: string): string =>
+	`/tmp/dsar-sqlite-migrations-${label}-${crypto.randomUUID()}.sqlite`;
+
+const runSqliteProgram = <A>(
+	filename: string,
+	program: (sql: Sql) => Effect.Effect<A, unknown>
+) =>
+	Effect.runPromise(
+		Effect.gen(function* runSqliteProgramEffect() {
+			const sql = yield* SqlClient.SqlClient;
+			return yield* program(sql);
+		}).pipe(
+			Effect.provide(
+				sqliteDriver({
+					create: true,
+					filename,
+				}).layer
+			)
+		)
+	);
+
+const makeSqliteContext = (label: string): MigrationTestContext => {
+	const filename = sqliteFile(label);
+	return {
+		cleanup: async () => {
+			await unlink(filename).catch(() => null);
+		},
+		run: (program) => runSqliteProgram(filename, program),
+	};
+};
+
+const inspectSqliteSchema = (sql: Sql) =>
+	Effect.gen(function* inspectSqliteSchemaProgram() {
+		const tables = yield* sql<{ readonly name: string }>`SELECT name
+			FROM sqlite_master
+			WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+			ORDER BY name`;
+		const indexes = yield* sql<{ readonly name: string }>`SELECT name
+			FROM sqlite_master
+			WHERE type = 'index' AND name NOT LIKE 'sqlite_%'
+			ORDER BY name`;
+		return {
+			indexes: indexes.map((row) => row.name),
+			tables: tables.map((row) => row.name),
+		};
+	});
+
+defineMigrationConformanceTests({
+	inspectSchema: inspectSqliteSchema,
+	makeContext: makeSqliteContext,
+	name: "sqlite",
+});


### PR DESCRIPTION
## Summary
- add an ordered persistence migration registry with `dsar_schema_migrations` metadata tracking
- keep production migrations forward-only while adding test-only rollback helpers for migration boundary coverage
- add shared SQLite/Postgres migration conformance tests for clean installs, prior-version upgrades, legacy row backfills, idempotent reruns, and migration metadata drift

Closes #18.

## Validation
- `bun run --cwd packages/persistence-sqlite test`
- `bun run --cwd packages/persistence-pg test` (Postgres migration scenarios skip when `DSAR_TEST_PG_URL` is unset)
- `bun run --cwd packages/internals/persistence test`
- `bun run --cwd packages/internals/persistence typecheck`
- `bun run --cwd packages/persistence-sqlite typecheck`
- `bun run --cwd packages/persistence-pg typecheck`
- `bun x ultracite check`