### PR TITLE
[webhooks] Add dead-letter queue and alerting hook

### DIFF
--- a/packages/backend/src/adapters/contract.ts
+++ b/packages/backend/src/adapters/contract.ts
@@ -1,6 +1,11 @@
 import type { Effect } from "effect";
 
-import type { NotificationEventType } from "../events/contracts";
+import type {
+	DeadDispatchAlertEvent,
+	NotificationEventType,
+} from "../events/contracts";
+
+export type { DeadDispatchAlertEvent };
 
 /**
  * Supported adapter capability groups used by the runtime registry.

--- a/packages/backend/src/events/contracts.ts
+++ b/packages/backend/src/events/contracts.ts
@@ -42,6 +42,22 @@ export interface NotificationEventDraft {
 }
 
 /**
+ * Event emitted when a webhook/email dispatch goes dead after exhausting retries.
+ */
+export interface DeadDispatchAlertEvent {
+	/** Unique event identifier. */
+	readonly eventId: string;
+	/** Channel that failed (webhook or email). */
+	readonly channel: string;
+	/** Destination URL or email address. */
+	readonly destination: string;
+	/** Tenant identifier. */
+	readonly tenantId: string;
+	/** When the dispatch was marked dead. */
+	readonly deadAt: string;
+}
+
+/**
  * Derives notification event drafts from a lifecycle transition.
  *
  * @param input - Lifecycle transition context and optional due-date/rationale data.

--- a/packages/backend/src/http-api/groups/webhooks.ts
+++ b/packages/backend/src/http-api/groups/webhooks.ts
@@ -37,7 +37,7 @@ const WebhookDispatchSchema = Schema.Struct({
 	notificationEventId: Schema.String,
 	requestId: Schema.String,
 	responseCode: Schema.optional(Schema.Number),
-	status: Schema.Literal("dead"),
+	status: Schema.Literals(["pending", "delivered", "failed", "skipped", "dead"]),
 });
 
 /** OpenAPI group describing public inbound webhook endpoints. */

--- a/packages/backend/src/http-api/groups/webhooks.ts
+++ b/packages/backend/src/http-api/groups/webhooks.ts
@@ -27,6 +27,19 @@ const WebhookRotateKeyResponseSchema = Schema.Struct({
 	previousKeyId: Schema.optional(Schema.String),
 });
 
+const WebhookDispatchSchema = Schema.Struct({
+	attempt: Schema.Number,
+	channel: Schema.String,
+	createdAt: Schema.String,
+	destination: Schema.String,
+	error: Schema.optional(Schema.String),
+	id: Schema.String,
+	notificationEventId: Schema.String,
+	requestId: Schema.String,
+	responseCode: Schema.optional(Schema.Number),
+	status: Schema.Literal("dead"),
+});
+
 /** OpenAPI group describing public inbound webhook endpoints. */
 export const webhooksGroup = HttpApiGroup.make("webhooks", { topLevel: true })
 	.add(
@@ -80,5 +93,27 @@ export const webhooksGroup = HttpApiGroup.make("webhooks", { topLevel: true })
 				}
 			),
 			"Rotate webhook endpoint signing key"
+		)
+	)
+	.add(
+		protectedOperation(
+			HttpApiEndpoint.get(
+				"webhooks_dispatches_list",
+				"/webhooks/dispatches",
+				{
+					query: {
+						status: Schema.optional(
+							Schema.Literals(["dead", "failed", "delivered", "pending", "skipped"])
+						),
+						limit: Schema.optional(Schema.Number),
+					},
+					success: successEnvelope(
+						Schema.Struct({
+							dispatches: Schema.Array(WebhookDispatchSchema),
+						})
+					),
+				}
+			),
+			"List webhook dispatches with optional status filter"
 		)
 	);

--- a/packages/backend/src/http-api/request-schemas.ts
+++ b/packages/backend/src/http-api/request-schemas.ts
@@ -143,7 +143,7 @@ export const NotificationEventSummarySchema = Schema.Struct({
 	createdAt: Schema.String,
 	eventId: Schema.String,
 	eventType: Schema.String,
-	status: Schema.Literals(["generated", "delivered", "failed", "skipped"]),
+	status: Schema.Literals(["generated", "delivered", "failed", "skipped", "dead"]),
 });
 
 /** Notification history response schema scoped to a request. */

--- a/packages/backend/src/http-api/request-schemas.ts
+++ b/packages/backend/src/http-api/request-schemas.ts
@@ -134,7 +134,7 @@ export const NotificationAttemptSchema = Schema.Struct({
 	destination: Schema.String,
 	error: Schema.optional(Schema.String),
 	responseCode: Schema.optional(Schema.Number),
-	status: Schema.Literals(["pending", "delivered", "failed", "skipped"]),
+	status: Schema.Literals(["pending", "delivered", "failed", "skipped", "dead"]),
 });
 
 /** Notification event summary schema grouped by originating event. */

--- a/packages/backend/src/routes/requests/shared.ts
+++ b/packages/backend/src/routes/requests/shared.ts
@@ -374,10 +374,13 @@ export const toVerificationMethod = (
  * @returns Aggregate notification event status.
  */
 export const resolveNotificationStatus = (
-	statuses: readonly ("pending" | "delivered" | "failed" | "skipped")[]
-): "generated" | "delivered" | "failed" | "skipped" => {
+	statuses: readonly ("pending" | "delivered" | "failed" | "skipped" | "dead")[]
+): "generated" | "delivered" | "failed" | "skipped" | "dead" => {
 	if (statuses.includes("delivered")) {
 		return "delivered";
+	}
+	if (statuses.includes("dead")) {
+		return "dead";
 	}
 	if (statuses.includes("failed")) {
 		return "failed";

--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -2,6 +2,7 @@ import type { RouteDefinition } from "./types";
 import { resendWebhookRoute } from "./webhooks/resend";
 import { rotateWebhookKeyRoute } from "./webhooks/rotate-key";
 import { slackWebhookRoute } from "./webhooks/slack";
+import { listWebhooksDispatchesRoute } from "./webhooks/dispatches";
 
 /**
  * Route definitions for inbound webhook endpoints that receive
@@ -11,4 +12,5 @@ export const webhookRoutes: readonly RouteDefinition[] = [
 	resendWebhookRoute,
 	slackWebhookRoute,
 	rotateWebhookKeyRoute,
+	listWebhooksDispatchesRoute,
 ];

--- a/packages/backend/src/routes/webhooks/dispatches.ts
+++ b/packages/backend/src/routes/webhooks/dispatches.ts
@@ -3,9 +3,28 @@ import * as Effect from "effect/Effect";
 
 import { requireRequestTenantId } from "../authz";
 import type { RouteDefinition } from "../types";
+import { RuntimeServicesTag } from "../../types/runtime";
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 500;
+
+const VALID_STATUSES = ["dead", "failed", "delivered", "pending", "skipped"] as const;
+type ValidStatus = (typeof VALID_STATUSES)[number];
+
+const parseStatusParam = (param: string | null): ValidStatus => {
+	const normalized = (param ?? "dead").toLowerCase();
+	return VALID_STATUSES.includes(normalized as ValidStatus)
+		? (normalized as ValidStatus)
+		: "dead";
+};
+
+const parseLimitParam = (param: string | null): number => {
+	const parsed = parseInt(param ?? String(DEFAULT_LIMIT), 10);
+	if (Number.isNaN(parsed)) {
+		return DEFAULT_LIMIT;
+	}
+	return Math.min(Math.max(1, parsed), MAX_LIMIT);
+};
 
 export const listWebhooksDispatchesRoute: RouteDefinition = {
 	kind: "http",
@@ -15,20 +34,14 @@ export const listWebhooksDispatchesRoute: RouteDefinition = {
 	handler: (request) =>
 		Effect.gen(function* listWebhooksDispatches() {
 			const url = new URL(request.url);
-			const statusParam = url.searchParams.get("status") ?? "dead";
-			const limitParam = url.searchParams.get("limit");
-			const limit = Math.min(
-				Math.max(1, parseInt(limitParam ?? String(DEFAULT_LIMIT), 10)),
-				MAX_LIMIT
-			);
+			const status = parseStatusParam(url.searchParams.get("status"));
+			const limit = parseLimitParam(url.searchParams.get("limit"));
 
-			const tenantId = yield* requireRequestTenantId;
-			const services = yield* Effect.service(
-				import("../../types/runtime").then((m) => m.RuntimeServicesTag)
-			);
+			const tenantId = yield* requireRequestTenantId();
+			const services = yield* Effect.service(RuntimeServicesTag);
 
 			const dispatches = yield* services.repos.persistence.notificationDeliveryAttempts
-				.listByStatus(statusParam as "dead", limit)
+				.listByStatus(status, limit)
 				.pipe(withTenant(tenantId));
 
 			return {

--- a/packages/backend/src/routes/webhooks/dispatches.ts
+++ b/packages/backend/src/routes/webhooks/dispatches.ts
@@ -1,0 +1,52 @@
+import { withTenant } from "@dsar/persistence";
+import * as Effect from "effect/Effect";
+
+import { requireRequestTenantId } from "../authz";
+import type { RouteDefinition } from "../types";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 500;
+
+export const listWebhooksDispatchesRoute: RouteDefinition = {
+	kind: "http",
+	method: "GET",
+	path: "/webhooks/dispatches",
+	format: "json",
+	handler: (request) =>
+		Effect.gen(function* listWebhooksDispatches() {
+			const url = new URL(request.url);
+			const statusParam = url.searchParams.get("status") ?? "dead";
+			const limitParam = url.searchParams.get("limit");
+			const limit = Math.min(
+				Math.max(1, parseInt(limitParam ?? String(DEFAULT_LIMIT), 10)),
+				MAX_LIMIT
+			);
+
+			const tenantId = yield* requireRequestTenantId;
+			const services = yield* Effect.service(
+				import("../../types/runtime").then((m) => m.RuntimeServicesTag)
+			);
+
+			const dispatches = yield* services.repos.persistence.notificationDeliveryAttempts
+				.listByStatus(statusParam as "dead", limit)
+				.pipe(withTenant(tenantId));
+
+			return {
+				status: 200,
+				body: {
+					dispatches: dispatches.map((d) => ({
+						attempt: d.attempt,
+						channel: d.channel,
+						createdAt: d.createdAt,
+						destination: d.destination,
+						error: d.error,
+						id: d.id,
+						notificationEventId: d.notificationEventId,
+						requestId: d.requestId,
+						responseCode: d.responseCode,
+						status: d.status,
+					})),
+				},
+			};
+		}),
+};

--- a/packages/backend/src/services/notifications/service.ts
+++ b/packages/backend/src/services/notifications/service.ts
@@ -22,6 +22,28 @@ const DEFAULT_LOCALE = "en-GB";
 const GENERATED_STATUS = "generated";
 const DEFAULT_WEBHOOK_ENDPOINT_ID = "default";
 
+const notifyDeadDispatch = (input: {
+	readonly eventId: string;
+	readonly channel: string;
+	readonly destination: string;
+	readonly tenantId: string;
+}): Effect.Effect<void, AppendDeliveryAttemptError, RuntimeServicesTag> =>
+	Effect.gen(function* notifyDeadDispatchProgram() {
+		const services = yield* Effect.service(RuntimeServicesTag);
+		if (services.config.onDeadDispatchAlert) {
+			const alertEvent = {
+				channel: input.channel,
+				destination: input.destination,
+				eventId: input.eventId,
+				tenantId: input.tenantId,
+				deadAt: new Date().toISOString(),
+			};
+			yield* Effect.tryPromise(() =>
+				Promise.resolve(services.config.onDeadDispatchAlert(alertEvent))
+			).pipe(Effect.catch(() => Effect.void));
+		}
+	});
+
 const toGeneratedResult = (
 	eventId: string
 ): {
@@ -237,6 +259,7 @@ const deliverWithRetries = (input: {
 						Promise.resolve(services.config.onAdapterEvent?.(adapterEvent))
 					).pipe(Effect.catch(() => Effect.void));
 				}
+				const isLastAttempt = attempt >= input.retryMaxAttempts || !normalized.retriable;
 				yield* appendDeliveryAttempt({
 					attempt,
 					channel: input.channel,
@@ -244,10 +267,16 @@ const deliverWithRetries = (input: {
 					error: normalized.message,
 					eventId: input.eventId,
 					requestId: input.requestId,
-					status: "failed",
+					status: isLastAttempt ? "dead" : "failed",
 					tenantId: input.tenantId,
 				});
-				if (attempt >= input.retryMaxAttempts || !normalized.retriable) {
+				if (isLastAttempt) {
+					yield* notifyDeadDispatch({
+						eventId: input.eventId,
+						channel: input.channel,
+						destination: input.destination,
+						tenantId: input.tenantId,
+					});
 					return;
 				}
 				yield* Effect.sleep(input.retryDelayMs);
@@ -272,6 +301,23 @@ const deliverWithRetries = (input: {
 				return;
 			}
 			if (attempt >= input.retryMaxAttempts) {
+				yield* appendDeliveryAttempt({
+					attempt: attempt + 1,
+					channel: input.channel,
+					destination: input.destination,
+					error: result.error ?? "Max retry attempts exhausted",
+					eventId: input.eventId,
+					requestId: input.requestId,
+					responseCode: result.responseCode,
+					status: "dead",
+					tenantId: input.tenantId,
+				});
+				yield* notifyDeadDispatch({
+					eventId: input.eventId,
+					channel: input.channel,
+					destination: input.destination,
+					tenantId: input.tenantId,
+				});
 				return;
 			}
 			yield* Effect.sleep(input.retryDelayMs);

--- a/packages/backend/src/services/notifications/service.ts
+++ b/packages/backend/src/services/notifications/service.ts
@@ -21,6 +21,7 @@ const DEFAULT_POLICY_VERSION = "policy-v1";
 const DEFAULT_LOCALE = "en-GB";
 const GENERATED_STATUS = "generated";
 const DEFAULT_WEBHOOK_ENDPOINT_ID = "default";
+const RETRY_EXHAUSTED_ERROR_MESSAGE = "Max retry attempts exhausted";
 
 const notifyDeadDispatch = (input: {
 	readonly eventId: string;
@@ -39,7 +40,7 @@ const notifyDeadDispatch = (input: {
 				deadAt: new Date().toISOString(),
 			};
 			yield* Effect.tryPromise(() =>
-				Promise.resolve(services.config.onDeadDispatchAlert(alertEvent))
+				services.config.onDeadDispatchAlert(alertEvent)
 			).pipe(Effect.catch(() => Effect.void));
 		}
 	});
@@ -301,11 +302,13 @@ const deliverWithRetries = (input: {
 				return;
 			}
 			if (attempt >= input.retryMaxAttempts) {
+				// Note: This creates a phantom attempt record (attempt + 1) to mark the final
+				// "dead" state since the last actual attempt already has its status set.
 				yield* appendDeliveryAttempt({
 					attempt: attempt + 1,
 					channel: input.channel,
 					destination: input.destination,
-					error: result.error ?? "Max retry attempts exhausted",
+					error: result.error ?? RETRY_EXHAUSTED_ERROR_MESSAGE,
 					eventId: input.eventId,
 					requestId: input.requestId,
 					responseCode: result.responseCode,

--- a/packages/backend/src/types/runtime.ts
+++ b/packages/backend/src/types/runtime.ts
@@ -4,6 +4,7 @@ import * as ServiceMap from "effect/ServiceMap";
 import type {
 	AdapterOperationalEvent,
 	AdapterRegistryService,
+	DeadDispatchAlertEvent,
 	InboundAdapterContract,
 	NotificationAdapterContract,
 	StorageAdapterContract,
@@ -130,6 +131,10 @@ export interface RuntimeConfig {
 	/** Optional observer for adapter failure/degradation events. */
 	readonly onAdapterEvent?: (
 		event: AdapterOperationalEvent
+	) => Promise<void> | void;
+	/** Optional callback for dead dispatch alerts (webhook/email delivery failures). */
+	readonly onDeadDispatchAlert?: (
+		event: DeadDispatchAlertEvent
 	) => Promise<void> | void;
 	/** Auth and identity resolution used by protected endpoints. */
 	readonly auth?: RuntimeAuthConfig;

--- a/packages/cli/src/commands/webhooks.ts
+++ b/packages/cli/src/commands/webhooks.ts
@@ -8,4 +8,6 @@ export const webhooksCommands = makeRouteCommands([
 	"webhooks_inbound_resend",
 	"webhooks_inbound_slack",
 	"webhooks_endpoint_rotate_key",
+	"webhooks_dispatches_list",
+	"webhooks_dispatches_replay",
 ] as const);

--- a/packages/cli/src/parity/route-map.ts
+++ b/packages/cli/src/parity/route-map.ts
@@ -105,7 +105,7 @@ export const routeParityMap: readonly RouteParityDefinition[] = [
 		path: "/webhooks/dispatches",
 	},
 	{
-		command: ["webhooks", "dlq", "replay", ":eventId"],
+		command: ["webhooks", "dlq", "replay", ":requestId", ":eventId"],
 		description: "Replay a dead notification event.",
 		id: "webhooks_dispatches_replay",
 		method: "POST",

--- a/packages/cli/src/parity/route-map.ts
+++ b/packages/cli/src/parity/route-map.ts
@@ -98,6 +98,20 @@ export const routeParityMap: readonly RouteParityDefinition[] = [
 		path: "/webhooks/endpoints/{id}/rotate-key",
 	},
 	{
+		command: ["webhooks", "dlq", "list"],
+		description: "List dead-letter queue (DLQ) dispatches.",
+		id: "webhooks_dispatches_list",
+		method: "GET",
+		path: "/webhooks/dispatches",
+	},
+	{
+		command: ["webhooks", "dlq", "replay", ":eventId"],
+		description: "Replay a dead notification event.",
+		id: "webhooks_dispatches_replay",
+		method: "POST",
+		path: "/requests/:requestId/notifications/:eventId/replay",
+	},
+	{
 		command: ["requests", "create"],
 		description: "Create request.",
 		id: "requests_create",

--- a/packages/internals/persistence/src/services/persistence.ts
+++ b/packages/internals/persistence/src/services/persistence.ts
@@ -940,6 +940,7 @@ const makePersistence = (
 				listByStatus: (status, limit = 50) =>
 					Effect.gen(function* listNotificationDeliveryAttemptsByStatus() {
 						const tenantId = yield* requireTenantId;
+						const clampedLimit = Math.min(Math.max(1, limit), 500);
 						const rows = yield* sql<{
 							readonly id: string;
 							readonly tenant_id: string;
@@ -955,7 +956,7 @@ const makePersistence = (
 						}>`SELECT * FROM notification_delivery_attempts
 					WHERE tenant_id = ${tenantId} AND status = ${status}
 					ORDER BY created_at DESC
-					LIMIT ${limit}`;
+					LIMIT ${clampedLimit}`;
 						return yield* Effect.forEach(
 							rows,
 							mapNotificationDeliveryAttemptRecordEffect

--- a/packages/internals/persistence/src/services/persistence.ts
+++ b/packages/internals/persistence/src/services/persistence.ts
@@ -937,6 +937,30 @@ const makePersistence = (
 							mapNotificationDeliveryAttemptRecordEffect
 						);
 					}),
+				listByStatus: (status, limit = 50) =>
+					Effect.gen(function* listNotificationDeliveryAttemptsByStatus() {
+						const tenantId = yield* requireTenantId;
+						const rows = yield* sql<{
+							readonly id: string;
+							readonly tenant_id: string;
+							readonly notification_event_id: string;
+							readonly request_id: string;
+							readonly channel: string;
+							readonly destination: string;
+							readonly attempt: number;
+							readonly status: string;
+							readonly response_code: number | null;
+							readonly error_text: string | null;
+							readonly created_at: string;
+						}>`SELECT * FROM notification_delivery_attempts
+					WHERE tenant_id = ${tenantId} AND status = ${status}
+					ORDER BY created_at DESC
+					LIMIT ${limit}`;
+						return yield* Effect.forEach(
+							rows,
+							mapNotificationDeliveryAttemptRecordEffect
+						);
+					}),
 			};
 
 		const webhookEndpoints: WebhookEndpointsRepository = {

--- a/packages/internals/persistence/src/services/persistence/shared.ts
+++ b/packages/internals/persistence/src/services/persistence/shared.ts
@@ -186,7 +186,8 @@ export const parseNotificationDeliveryStatus = (
 		case "pending":
 		case "delivered":
 		case "failed":
-		case "skipped": {
+		case "skipped":
+		case "dead": {
 			return Effect.succeed(value);
 		}
 		default: {

--- a/packages/internals/persistence/src/types/domain.ts
+++ b/packages/internals/persistence/src/types/domain.ts
@@ -623,7 +623,8 @@ export type NotificationDeliveryStatus =
 	| "pending"
 	| "delivered"
 	| "failed"
-	| "skipped";
+	| "skipped"
+	| "dead";
 
 /**
  * Immutable delivery-attempt event record associated with a notification event.
@@ -1387,6 +1388,23 @@ export interface NotificationDeliveryAttemptsRepository {
 	 */
 	readonly listByNotificationEventId: (
 		notificationEventId: string
+	) => Effect.Effect<
+		readonly NotificationDeliveryAttemptRecord[],
+		PersistenceError | SqlError,
+		TenantContext
+	>;
+	/**
+	 * Lists delivery attempts filtered by status.
+	 *
+	 * @param status - Optional status filter (e.g. "dead" for DLQ).
+	 * @param limit - Maximum number of results.
+	 * @returns An ordered array of {@link NotificationDeliveryAttemptRecord} entries.
+	 * @throws {@link PersistenceError} on mapping failures.
+	 * @throws {@link SqlError} on underlying database failures.
+	 */
+	readonly listByStatus: (
+		status: NotificationDeliveryStatus,
+		limit?: number
 	) => Effect.Effect<
 		readonly NotificationDeliveryAttemptRecord[],
 		PersistenceError | SqlError,

--- a/packages/internals/persistence/src/types/domain.ts
+++ b/packages/internals/persistence/src/types/domain.ts
@@ -1396,8 +1396,8 @@ export interface NotificationDeliveryAttemptsRepository {
 	/**
 	 * Lists delivery attempts filtered by status.
 	 *
-	 * @param status - Optional status filter (e.g. "dead" for DLQ).
-	 * @param limit - Maximum number of results.
+	 * @param status - Status filter (e.g. "dead" for DLQ).
+	 * @param limit - Maximum number of results (default: 50, max: 500).
 	 * @returns An ordered array of {@link NotificationDeliveryAttemptRecord} entries.
 	 * @throws {@link PersistenceError} on mapping failures.
 	 * @throws {@link SqlError} on underlying database failures.

--- a/packages/node-sdk/src/endpoints/types/requests.ts
+++ b/packages/node-sdk/src/endpoints/types/requests.ts
@@ -192,7 +192,7 @@ export interface NotificationEventPayload {
 	/** Timestamp when this record was created. */
 	readonly createdAt: string;
 	/** Aggregate delivery status for the notification event. */
-	readonly status: "generated" | "delivered" | "failed" | "skipped";
+	readonly status: "generated" | "delivered" | "failed" | "skipped" | "dead";
 	/** Delivery attempts recorded for this notification event. */
 	readonly attempts: readonly NotificationAttemptPayload[];
 }

--- a/packages/node-sdk/src/endpoints/types/requests.ts
+++ b/packages/node-sdk/src/endpoints/types/requests.ts
@@ -174,7 +174,7 @@ export interface NotificationAttemptPayload {
 	/** Timestamp when this record was created. */
 	readonly createdAt: string;
 	/** Delivery result for this specific attempt. */
-	readonly status: "pending" | "delivered" | "failed" | "skipped";
+	readonly status: "pending" | "delivered" | "failed" | "skipped" | "dead";
 	/** Provider response code returned for this attempt. */
 	readonly responseCode?: number;
 	/** Failure reason returned by the provider or runtime. */


### PR DESCRIPTION
- Add 'dead' status to NotificationDeliveryStatus after max retry attempts
- Add listByStatus() to NotificationDeliveryAttemptsRepository for DLQ queries
- Add GET /webhooks/dispatches endpoint with status filter
- Add onDeadDispatchAlert callback for tenant-level alerting
- Add CLI commands: webhooks dlq list, webhooks dlq replay