### PR TITLE
Set Bun minimum dependency age

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[install]
+minimumReleaseAge = 86400


### PR DESCRIPTION
## Summary

Adds a root `bunfig.toml` that configures Bun installs to ignore npm package versions published within the last 24 hours.

## Impact

New dependency resolution now applies a 24-hour minimum release age gate for direct and transitive npm packages. Existing versions already pinned in `bun.lock` remain unchanged.

## Validation

- `bun install --dry-run --frozen-lockfile --ignore-scripts`