### PR TITLE
Add operator-facing audit log view (#26)

### DIFF
--- a/packages/backend/src/audit/export.ts
+++ b/packages/backend/src/audit/export.ts
@@ -10,16 +10,30 @@ const DEFAULT_TENANT_ID = "tenant-default";
 const EXPORT_HARD_CAP = 10_000;
 const EXPORT_PAGE_SIZE = 500;
 
+/**
+ * Serialised projection of an immutable audit event used for compliance
+ * export payloads. Mirrors the public schema in `@dsar/schema`.
+ */
 export interface ExportedAuditEvent {
+	/** Immutable audit event identifier. */
 	readonly id: string;
+	/** Event-type name (derived from the audit `action`). */
 	readonly eventType: string;
+	/** Actor or principal responsible for the event. */
 	readonly actor: string;
+	/** Timestamp when the event was recorded. */
 	readonly occurredAt: string;
+	/** Tamper-evident chain hash for this event. */
 	readonly hash: string;
+	/** Hash algorithm identifier used to compute `hash`. */
 	readonly hashAlg: string;
+	/** Hash of the preceding event in the chain, when present. */
 	readonly prevHash?: string;
+	/** Monotonic sequence number used for deterministic ordering. */
 	readonly sequence: number;
+	/** Structured before/after/reason/object payload kept beside the event. */
 	readonly metadata: Record<string, unknown>;
+	/** Request id this event belongs to. */
 	readonly requestId: string;
 }
 
@@ -44,6 +58,35 @@ const toExportedEvent = (
 	sequence: record.sequence,
 });
 
+const escapeCsvField = (value: string | number | undefined): string => {
+	if (value === undefined) {
+		return "";
+	}
+	const text = String(value);
+	if (
+		text.includes(",") ||
+		text.includes('"') ||
+		text.includes("\n") ||
+		text.includes("\r")
+	) {
+		return `"${text.replaceAll('"', '""')}"`;
+	}
+	return text;
+};
+
+const toCsvRow = (event: ExportedAuditEvent): string =>
+	[
+		event.id,
+		event.eventType,
+		event.actor,
+		event.occurredAt,
+		event.sequence,
+		event.hash,
+		event.prevHash,
+	]
+		.map(escapeCsvField)
+		.join(",");
+
 const serializeAuditEvents = (
 	events: readonly ExportedAuditEvent[],
 	format: "jsonl" | "csv"
@@ -52,10 +95,7 @@ const serializeAuditEvents = (
 		? events.map((event) => JSON.stringify(event)).join("\n")
 		: [
 				"id,eventType,actor,occurredAt,sequence,hash,prevHash",
-				...events.map(
-					(event) =>
-						`${event.id},${event.eventType},${event.actor},${event.occurredAt},${event.sequence},${event.hash},${event.prevHash ?? ""}`
-				),
+				...events.map(toCsvRow),
 			].join("\n");
 
 /**
@@ -221,8 +261,9 @@ export const verifyAuditChain = (input: {
  * @param [input.until] - Inclusive upper bound (ISO-8601).
  * @param input.format - Serialisation format (`"jsonl"` or `"csv"`).
  * @returns An `Effect` yielding the event array, the serialised string,
- *   the chosen format, the bounds used, and the `rootHash` of the latest
- *   event in the window (for chain verification).
+ *   the chosen format, the bounds used, and two chain-verification
+ *   anchors: `rootHash` (earliest event in the window, chronologically
+ *   first) and `tipHash` (latest event in the window).
  * @throws {@link RequestValidationError} When the export exceeds the row
  *   cap or the underlying persistence query fails.
  */
@@ -238,6 +279,7 @@ export const exportAuditEventsTenantWide = (input: {
 		readonly until?: string;
 		readonly events: readonly ExportedAuditEvent[];
 		readonly rootHash?: string;
+		readonly tipHash?: string;
 		readonly serialized: string;
 	},
 	RequestValidationError,
@@ -279,12 +321,16 @@ export const exportAuditEventsTenantWide = (input: {
 			toExportedEvent(record, record.requestId ?? "")
 		);
 		const serialized = serializeAuditEvents(events, input.format);
+		// Persistence returns rows ORDER BY created_at DESC, id DESC, so the
+		// last entry is the earliest event in the window (root) and the
+		// first entry is the latest (tip).
 		return {
 			events,
 			format: input.format,
-			rootHash: events.at(0)?.hash,
+			rootHash: events.at(-1)?.hash,
 			serialized,
 			since: input.since,
+			tipHash: events.at(0)?.hash,
 			until: input.until,
 		};
 	}).pipe(

--- a/packages/backend/src/audit/export.ts
+++ b/packages/backend/src/audit/export.ts
@@ -1,3 +1,4 @@
+import type { AuditEventCursor, AuditEventRecord } from "@dsar/persistence";
 import { withTenant } from "@dsar/persistence";
 import * as Effect from "effect/Effect";
 
@@ -6,6 +7,56 @@ import { RuntimeServicesTag } from "../types/runtime";
 import { computeAuditHash } from "./hash-chain";
 
 const DEFAULT_TENANT_ID = "tenant-default";
+const EXPORT_HARD_CAP = 10_000;
+const EXPORT_PAGE_SIZE = 500;
+
+export interface ExportedAuditEvent {
+	readonly id: string;
+	readonly eventType: string;
+	readonly actor: string;
+	readonly occurredAt: string;
+	readonly hash: string;
+	readonly hashAlg: string;
+	readonly prevHash?: string;
+	readonly sequence: number;
+	readonly metadata: Record<string, unknown>;
+	readonly requestId: string;
+}
+
+const toExportedEvent = (
+	record: AuditEventRecord,
+	fallbackRequestId: string
+): ExportedAuditEvent => ({
+	actor: record.actor,
+	eventType: record.action,
+	hash: record.hash,
+	hashAlg: record.hashAlg,
+	id: record.id,
+	metadata: {
+		after: record.after,
+		before: record.before,
+		object: record.object,
+		reason: record.reason,
+	},
+	occurredAt: record.createdAt,
+	prevHash: record.prevHash,
+	requestId: record.requestId ?? fallbackRequestId,
+	sequence: record.sequence,
+});
+
+const serializeAuditEvents = (
+	events: readonly ExportedAuditEvent[],
+	format: "jsonl" | "csv"
+): string =>
+	format === "jsonl"
+		? events.map((event) => JSON.stringify(event)).join("\n")
+		: [
+				"id,eventType,actor,occurredAt,sequence,hash,prevHash",
+				...events.map(
+					(event) =>
+						`${event.id},${event.eventType},${event.actor},${event.occurredAt},${event.sequence},${event.hash},${event.prevHash ?? ""}`
+				),
+			].join("\n");
 
 /**
  * Exports audit events for a request as serialised JSONL or CSV.
@@ -52,35 +103,10 @@ export const exportAuditEvents = (input: {
 		const records = yield* services.repos.persistence.auditEvents
 			.listByRequestId(input.requestId)
 			.pipe(withTenant(tenantId));
-
-		const events = records.map((record) => ({
-			actor: record.actor,
-			eventType: record.action,
-			hash: record.hash,
-			hashAlg: record.hashAlg,
-			id: record.id,
-			metadata: {
-				after: record.after,
-				before: record.before,
-				object: record.object,
-				reason: record.reason,
-			},
-			occurredAt: record.createdAt,
-			prevHash: record.prevHash,
-			requestId: record.requestId ?? input.requestId,
-			sequence: record.sequence,
-		}));
-
-		const serialized =
-			input.format === "jsonl"
-				? events.map((event) => JSON.stringify(event)).join("\n")
-				: [
-						"id,eventType,actor,occurredAt,sequence,hash,prevHash",
-						...events.map(
-							(event) =>
-								`${event.id},${event.eventType},${event.actor},${event.occurredAt},${event.sequence},${event.hash},${event.prevHash ?? ""}`
-						),
-					].join("\n");
+		const events = records.map((record) =>
+			toExportedEvent(record, input.requestId)
+		);
+		const serialized = serializeAuditEvents(events, input.format);
 		return {
 			events,
 			format: input.format,
@@ -177,6 +203,98 @@ export const verifyAuditChain = (input: {
 					: new RequestValidationError({
 							details: { cause: String(error) },
 							message: "Failed to verify audit hash chain.",
+							reasonCode: "INTERNAL_RUNTIME_ERROR",
+						})
+			)
+		)
+	);
+
+/**
+ * Exports the tenant-wide audit trail bounded by an inclusive time window.
+ *
+ * Paginates the underlying audit repository up to {@link EXPORT_HARD_CAP}
+ * rows. Beyond the cap, callers must narrow the window with `since`/`until`.
+ *
+ * @param input - Export parameters.
+ * @param input.tenantId - Tenant whose audit trail is exported.
+ * @param input.since - Inclusive lower bound (ISO-8601).
+ * @param [input.until] - Inclusive upper bound (ISO-8601).
+ * @param input.format - Serialisation format (`"jsonl"` or `"csv"`).
+ * @returns An `Effect` yielding the event array, the serialised string,
+ *   the chosen format, the bounds used, and the `rootHash` of the latest
+ *   event in the window (for chain verification).
+ * @throws {@link RequestValidationError} When the export exceeds the row
+ *   cap or the underlying persistence query fails.
+ */
+export const exportAuditEventsTenantWide = (input: {
+	readonly tenantId: string;
+	readonly since: string;
+	readonly until?: string;
+	readonly format: "jsonl" | "csv";
+}): Effect.Effect<
+	{
+		readonly format: "jsonl" | "csv";
+		readonly since: string;
+		readonly until?: string;
+		readonly events: readonly ExportedAuditEvent[];
+		readonly rootHash?: string;
+		readonly serialized: string;
+	},
+	RequestValidationError,
+	RuntimeServicesTag
+> =>
+	Effect.gen(function* exportAuditEventsTenantWideProgram() {
+		const services = yield* Effect.service(RuntimeServicesTag);
+		const collected: AuditEventRecord[] = [];
+		let cursor: AuditEventCursor | undefined;
+		while (collected.length <= EXPORT_HARD_CAP) {
+			const page = yield* services.repos.persistence.auditEvents
+				.list({
+					createdAfter: input.since,
+					createdBefore: input.until,
+					cursor,
+					limit: EXPORT_PAGE_SIZE,
+				})
+				.pipe(withTenant(input.tenantId));
+			collected.push(...page.items);
+			if (!page.nextCursor) {
+				break;
+			}
+			cursor = page.nextCursor;
+		}
+		if (collected.length > EXPORT_HARD_CAP) {
+			return yield* Effect.fail(
+				new RequestValidationError({
+					details: {
+						cap: EXPORT_HARD_CAP,
+						since: input.since,
+						until: input.until,
+					},
+					message: `Audit export exceeded ${EXPORT_HARD_CAP} rows. Narrow the window with \`since\`/\`until\` and retry.`,
+					reasonCode: "REQUEST_VALIDATION_FAILED",
+				})
+			);
+		}
+		const events = collected.map((record) =>
+			toExportedEvent(record, record.requestId ?? "")
+		);
+		const serialized = serializeAuditEvents(events, input.format);
+		return {
+			events,
+			format: input.format,
+			rootHash: events.at(0)?.hash,
+			serialized,
+			since: input.since,
+			until: input.until,
+		};
+	}).pipe(
+		Effect.catch((error) =>
+			Effect.fail(
+				error instanceof RequestValidationError
+					? error
+					: new RequestValidationError({
+							details: { cause: String(error) },
+							message: "Failed to export tenant audit events.",
 							reasonCode: "INTERNAL_RUNTIME_ERROR",
 						})
 			)

--- a/packages/backend/src/http-api/api.ts
+++ b/packages/backend/src/http-api/api.ts
@@ -1,6 +1,7 @@
 import * as HttpApi from "effect/unstable/httpapi/HttpApi";
 import * as OpenApi from "effect/unstable/httpapi/OpenApi";
 
+import { auditGroup } from "./groups/audit";
 import { initGroup } from "./groups/init";
 import { policiesGroup } from "./groups/policies";
 import { requestsGroup } from "./groups/requests";
@@ -22,6 +23,7 @@ export const makeDsarHttpApi = (basePath: string) =>
 		.add(statusGroup)
 		.add(webhooksGroup)
 		.add(subjectsGroup)
+		.add(auditGroup)
 		.add(policiesGroup)
 		.add(requestsGroup)
 		.annotateMerge(

--- a/packages/backend/src/http-api/groups/audit.ts
+++ b/packages/backend/src/http-api/groups/audit.ts
@@ -74,6 +74,7 @@ export const auditGroup = HttpApiGroup.make("audit", { topLevel: true })
 						format: Schema.Literals(["jsonl", "csv"]),
 						rootHash: Schema.optional(Schema.String),
 						since: Schema.String,
+						tipHash: Schema.optional(Schema.String),
 						until: Schema.optional(Schema.String),
 					})
 				).pipe(s200),

--- a/packages/backend/src/http-api/groups/audit.ts
+++ b/packages/backend/src/http-api/groups/audit.ts
@@ -1,0 +1,83 @@
+import * as Schema from "effect/Schema";
+import * as HttpApiEndpoint from "effect/unstable/httpapi/HttpApiEndpoint";
+import * as HttpApiGroup from "effect/unstable/httpapi/HttpApiGroup";
+
+import { protectedOperation, s200 } from "../common";
+import { successEnvelope } from "../schemas";
+
+const AuditListItemSchema = Schema.Struct({
+	action: Schema.String,
+	actor: Schema.String,
+	createdAt: Schema.String,
+	hash: Schema.String,
+	hashAlg: Schema.String,
+	id: Schema.String,
+	object: Schema.String,
+	prevHash: Schema.optional(Schema.String),
+	requestId: Schema.optional(Schema.String),
+	sequence: Schema.Number,
+});
+
+const AuditExportEventSchema = Schema.Struct({
+	actor: Schema.String,
+	eventType: Schema.String,
+	hash: Schema.String,
+	hashAlg: Schema.String,
+	id: Schema.String,
+	metadata: Schema.Record(Schema.String, Schema.Unknown),
+	occurredAt: Schema.String,
+	prevHash: Schema.optional(Schema.String),
+	requestId: Schema.String,
+	sequence: Schema.Number,
+});
+
+/** OpenAPI group describing the operator-facing audit log endpoints. */
+export const auditGroup = HttpApiGroup.make("audit", { topLevel: true })
+	.add(
+		protectedOperation(
+			HttpApiEndpoint.get("audit_list", "/audit", {
+				query: {
+					actor: Schema.optional(Schema.String),
+					created_after: Schema.optional(Schema.String),
+					created_before: Schema.optional(Schema.String),
+					cursor: Schema.optional(Schema.String),
+					event_type: Schema.optional(Schema.String),
+					limit: Schema.optional(Schema.NumberFromString),
+					request_id: Schema.optional(Schema.String),
+					subject_id: Schema.optional(Schema.String),
+				},
+				success: successEnvelope(
+					Schema.Struct({
+						items: Schema.Array(AuditListItemSchema),
+						pagination: Schema.Struct({
+							limit: Schema.Number,
+							nextCursor: Schema.optional(Schema.String),
+						}),
+					})
+				).pipe(s200),
+			}),
+			"List audit events"
+		)
+	)
+	.add(
+		protectedOperation(
+			HttpApiEndpoint.get("audit_export", "/audit/export", {
+				query: {
+					format: Schema.optional(Schema.Literals(["jsonl", "csv"])),
+					since: Schema.String,
+					until: Schema.optional(Schema.String),
+				},
+				success: successEnvelope(
+					Schema.Struct({
+						eventCount: Schema.Number,
+						events: Schema.Array(AuditExportEventSchema),
+						format: Schema.Literals(["jsonl", "csv"]),
+						rootHash: Schema.optional(Schema.String),
+						since: Schema.String,
+						until: Schema.optional(Schema.String),
+					})
+				).pipe(s200),
+			}),
+			"Export tenant audit trail"
+		)
+	);

--- a/packages/backend/src/routes/audit.ts
+++ b/packages/backend/src/routes/audit.ts
@@ -1,0 +1,267 @@
+import type { AuditEventCursor } from "@dsar/persistence";
+import { withTenant } from "@dsar/persistence";
+import { IsoTimestampSchema } from "@dsar/schema";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Schema from "effect/Schema";
+
+import { exportAuditEventsTenantWide } from "../audit/export";
+import {
+	ForbiddenRequestError,
+	RequestValidationError,
+	UnauthorizedRequestError,
+} from "../types/errors";
+import { RuntimeServicesTag } from "../types/runtime";
+import {
+	requirePrincipalKinds,
+	requireRequestActor,
+	requireRequestTenantId,
+} from "./authz";
+import { ok } from "./helpers";
+import {
+	DEFAULT_LIST_LIMIT,
+	MAX_LIST_LIMIT,
+	parseIntParam,
+	toValidationFailure,
+} from "./requests/shared";
+import type { RouteDefinition } from "./types";
+
+const normalizeIsoTimestamp = (value: string): string | undefined => {
+	const decoded = Schema.decodeUnknownExit(IsoTimestampSchema)(value);
+	if (Exit.isFailure(decoded)) {
+		return undefined;
+	}
+	return new Date(decoded.value).toISOString();
+};
+
+const parseIsoTimestampParam = (
+	value: string | null,
+	paramName: string
+): Effect.Effect<
+	string | undefined,
+	ReturnType<typeof toValidationFailure>
+> => {
+	if (!value || value.trim().length === 0) {
+		return Effect.succeed(undefined as string | undefined);
+	}
+	const normalized = normalizeIsoTimestamp(value);
+	if (!normalized) {
+		return Effect.fail(
+			toValidationFailure(
+				`${paramName} must be a valid ISO-8601 timestamp.`,
+				new Error(`Received ${paramName}=${value}`)
+			)
+		);
+	}
+	return Effect.succeed(normalized);
+};
+
+const encodeCursor = (cursor: AuditEventCursor): string =>
+	Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+
+const decodeCursor = (value: string | null): AuditEventCursor | undefined => {
+	if (!value) {
+		return undefined;
+	}
+	try {
+		const parsed: unknown = JSON.parse(
+			Buffer.from(value, "base64url").toString("utf8")
+		);
+		if (
+			typeof parsed === "object" &&
+			parsed !== null &&
+			"createdAt" in parsed &&
+			"id" in parsed &&
+			typeof parsed.createdAt === "string" &&
+			typeof parsed.id === "string"
+		) {
+			const { createdAt, id } = parsed;
+			const normalizedCreatedAt = normalizeIsoTimestamp(createdAt);
+			if (!normalizedCreatedAt || id.trim().length === 0) {
+				return undefined;
+			}
+			return { createdAt: normalizedCreatedAt, id };
+		}
+	} catch {
+		return undefined;
+	}
+	return undefined;
+};
+
+const OPERATOR_MESSAGE =
+	"The audit log is reserved for operator or service principals.";
+
+const requireOperator = Effect.gen(function* requireOperatorEffect() {
+	const services = yield* Effect.service(RuntimeServicesTag);
+	const actor = yield* requireRequestActor(services.requestContext);
+	yield* requirePrincipalKinds({
+		actor,
+		allowedKinds: ["operator", "service"],
+		message: OPERATOR_MESSAGE,
+	});
+	const tenantId = yield* requireRequestTenantId(services.requestContext);
+	return { services, tenantId };
+});
+
+const trimmed = (value: string | null): string | undefined => {
+	if (!value) {
+		return undefined;
+	}
+	const v = value.trim();
+	return v.length > 0 ? v : undefined;
+};
+
+/**
+ * Route definitions for the operator-facing `/audit` namespace: browsing
+ * and exporting the immutable, hash-chained audit log for compliance review.
+ */
+export const auditRoutes: readonly RouteDefinition[] = [
+	{
+		handler: ({ request }) =>
+			Effect.gen(function* listAuditHandler() {
+				const { services, tenantId } = yield* requireOperator;
+				const { searchParams } = new URL(request.url);
+				const limit = parseIntParam(
+					searchParams.get("limit"),
+					DEFAULT_LIST_LIMIT,
+					1,
+					MAX_LIST_LIMIT
+				);
+				const cursorParam = searchParams.get("cursor");
+				const cursor = decodeCursor(cursorParam);
+				if (cursorParam && !cursor) {
+					return yield* Effect.fail(
+						toValidationFailure(
+							"Invalid audit pagination cursor.",
+							new Error("Cursor must be a cursor returned by this endpoint.")
+						)
+					);
+				}
+				const createdAfter = yield* parseIsoTimestampParam(
+					searchParams.get("created_after"),
+					"created_after"
+				);
+				const createdBefore = yield* parseIsoTimestampParam(
+					searchParams.get("created_before"),
+					"created_before"
+				);
+				const requestId = trimmed(searchParams.get("request_id"));
+				const subjectId = trimmed(searchParams.get("subject_id"));
+				const actor = trimmed(searchParams.get("actor"));
+				const action = trimmed(searchParams.get("event_type"));
+				let requestIds: readonly string[] | undefined;
+				if (subjectId) {
+					const subjectPage = yield* services.repos.persistence.requests
+						.listBySubject({
+							identifiers: [subjectId],
+							limit: MAX_LIST_LIMIT,
+						})
+						.pipe(withTenant(tenantId));
+					requestIds = subjectPage.items.map((record) => record.id);
+					if (requestIds.length === 0) {
+						return ok({
+							items: [],
+							pagination: { limit, nextCursor: undefined },
+						});
+					}
+				}
+				const page = yield* services.repos.persistence.auditEvents
+					.list({
+						action,
+						actor,
+						createdAfter,
+						createdBefore,
+						cursor,
+						limit,
+						requestId,
+						requestIds,
+					})
+					.pipe(withTenant(tenantId));
+				return ok({
+					items: page.items.map((event) => ({
+						action: event.action,
+						actor: event.actor,
+						createdAt: event.createdAt,
+						hash: event.hash,
+						hashAlg: event.hashAlg,
+						id: event.id,
+						object: event.object,
+						prevHash: event.prevHash,
+						requestId: event.requestId,
+						sequence: event.sequence,
+					})),
+					pagination: {
+						limit: page.limit,
+						nextCursor: page.nextCursor
+							? encodeCursor(page.nextCursor)
+							: undefined,
+					},
+				});
+			}).pipe(
+				Effect.catch((error) =>
+					Effect.fail(
+						error instanceof ForbiddenRequestError ||
+							error instanceof UnauthorizedRequestError ||
+							error instanceof RequestValidationError
+							? error
+							: toValidationFailure("Failed to list audit events.", error)
+					)
+				)
+			),
+		method: "GET",
+		path: "/audit",
+		protected: true,
+		summary: "List audit events",
+	},
+	{
+		handler: ({ request }) =>
+			Effect.gen(function* exportAuditHandler() {
+				const { tenantId } = yield* requireOperator;
+				const { searchParams } = new URL(request.url);
+				const sinceParam = searchParams.get("since");
+				if (!sinceParam || sinceParam.trim().length === 0) {
+					return yield* Effect.fail(
+						toValidationFailure(
+							"`since` is required for tenant-wide audit export.",
+							new Error("Missing required query parameter: since")
+						)
+					);
+				}
+				const since = yield* parseIsoTimestampParam(sinceParam, "since");
+				const until = yield* parseIsoTimestampParam(
+					searchParams.get("until"),
+					"until"
+				);
+				const formatParam = searchParams.get("format");
+				const format = formatParam === "csv" ? "csv" : "jsonl";
+				const exported = yield* exportAuditEventsTenantWide({
+					format,
+					since: since ?? sinceParam,
+					tenantId,
+					until,
+				});
+				return ok({
+					eventCount: exported.events.length,
+					events: exported.events,
+					format: exported.format,
+					rootHash: exported.rootHash,
+					since: exported.since,
+					until: exported.until,
+				});
+			}).pipe(
+				Effect.catch((error) =>
+					Effect.fail(
+						error instanceof ForbiddenRequestError ||
+							error instanceof UnauthorizedRequestError ||
+							error instanceof RequestValidationError
+							? error
+							: toValidationFailure("Failed to export audit events.", error)
+					)
+				)
+			),
+		method: "GET",
+		path: "/audit/export",
+		protected: true,
+		summary: "Export tenant audit trail",
+	},
+];

--- a/packages/backend/src/routes/audit.ts
+++ b/packages/backend/src/routes/audit.ts
@@ -1,4 +1,4 @@
-import type { AuditEventCursor } from "@dsar/persistence";
+import type { AuditEventCursor, RequestSubjectCursor } from "@dsar/persistence";
 import { withTenant } from "@dsar/persistence";
 import { IsoTimestampSchema } from "@dsar/schema";
 import * as Effect from "effect/Effect";
@@ -11,6 +11,7 @@ import {
 	RequestValidationError,
 	UnauthorizedRequestError,
 } from "../types/errors";
+import type { RuntimeServices } from "../types/runtime";
 import { RuntimeServicesTag } from "../types/runtime";
 import {
 	requirePrincipalKinds,
@@ -91,6 +92,44 @@ const decodeCursor = (value: string | null): AuditEventCursor | undefined => {
 const OPERATOR_MESSAGE =
 	"The audit log is reserved for operator or service principals.";
 
+const SUBJECT_REQUEST_EXPANSION_CAP = 10_000;
+
+const collectRequestIdsForSubject = (
+	services: RuntimeServices,
+	tenantId: string,
+	subjectId: string
+) =>
+	Effect.gen(function* collectRequestIdsForSubjectEffect() {
+		const collected: string[] = [];
+		let cursor: RequestSubjectCursor | undefined;
+		do {
+			const page = yield* services.repos.persistence.requests
+				.listBySubject({
+					cursor,
+					identifiers: [subjectId],
+					limit: MAX_LIST_LIMIT,
+				})
+				.pipe(withTenant(tenantId));
+			for (const record of page.items) {
+				collected.push(record.id);
+			}
+			if (collected.length > SUBJECT_REQUEST_EXPANSION_CAP) {
+				return yield* Effect.fail(
+					new RequestValidationError({
+						details: {
+							cap: SUBJECT_REQUEST_EXPANSION_CAP,
+							subjectId,
+						},
+						message: `subject_id matches more than ${SUBJECT_REQUEST_EXPANSION_CAP} requests; narrow with created_after/created_before or request_id.`,
+						reasonCode: "REQUEST_VALIDATION_FAILED",
+					})
+				);
+			}
+			cursor = page.nextCursor;
+		} while (cursor);
+		return collected;
+	});
+
 const requireOperator = Effect.gen(function* requireOperatorEffect() {
 	const services = yield* Effect.service(RuntimeServicesTag);
 	const actor = yield* requireRequestActor(services.requestContext);
@@ -151,13 +190,11 @@ export const auditRoutes: readonly RouteDefinition[] = [
 				const action = trimmed(searchParams.get("event_type"));
 				let requestIds: readonly string[] | undefined;
 				if (subjectId) {
-					const subjectPage = yield* services.repos.persistence.requests
-						.listBySubject({
-							identifiers: [subjectId],
-							limit: MAX_LIST_LIMIT,
-						})
-						.pipe(withTenant(tenantId));
-					requestIds = subjectPage.items.map((record) => record.id);
+					requestIds = yield* collectRequestIdsForSubject(
+						services,
+						tenantId,
+						subjectId
+					);
 					if (requestIds.length === 0) {
 						return ok({
 							items: [],
@@ -233,7 +270,19 @@ export const auditRoutes: readonly RouteDefinition[] = [
 					"until"
 				);
 				const formatParam = searchParams.get("format");
-				const format = formatParam === "csv" ? "csv" : "jsonl";
+				if (
+					formatParam !== null &&
+					formatParam !== "csv" &&
+					formatParam !== "jsonl"
+				) {
+					return yield* Effect.fail(
+						toValidationFailure(
+							"`format` must be either `jsonl` or `csv`.",
+							new Error(`Unsupported format=${formatParam}`)
+						)
+					);
+				}
+				const format: "jsonl" | "csv" = formatParam === "csv" ? "csv" : "jsonl";
 				const exported = yield* exportAuditEventsTenantWide({
 					format,
 					since: since ?? sinceParam,
@@ -246,6 +295,7 @@ export const auditRoutes: readonly RouteDefinition[] = [
 					format: exported.format,
 					rootHash: exported.rootHash,
 					since: exported.since,
+					tipHash: exported.tipHash,
 					until: exported.until,
 				});
 			}).pipe(

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -1,3 +1,4 @@
+import { auditRoutes } from "./audit";
 import { initRoutes } from "./init";
 import { policyRoutes } from "./policies";
 import { requestRoutes } from "./requests";
@@ -8,7 +9,7 @@ import { webhookRoutes } from "./webhooks";
 
 /**
  * Aggregate route table combining all backend endpoint groups (init,
- * webhooks, requests, subjects, policies, status) into a single
+ * webhooks, requests, subjects, audit, policies, status) into a single
  * ordered array matched by the request router.
  */
 export const coreRoutes: readonly RouteDefinition[] = [
@@ -16,6 +17,7 @@ export const coreRoutes: readonly RouteDefinition[] = [
 	...webhookRoutes,
 	...requestRoutes,
 	...subjectRoutes,
+	...auditRoutes,
 	...policyRoutes,
 	...statusRoutes,
 ];

--- a/packages/backend/src/testing/minimal-persistence.ts
+++ b/packages/backend/src/testing/minimal-persistence.ts
@@ -93,6 +93,11 @@ export interface MinimalPersistence {
 		readonly listByRequestId: (
 			requestId: string
 		) => Effect.Effect<readonly Record<string, unknown>[]>;
+		readonly list: (input: Record<string, unknown>) => Effect.Effect<{
+			readonly items: readonly Record<string, unknown>[];
+			readonly limit: number;
+			readonly nextCursor?: { readonly createdAt: string; readonly id: string };
+		}>;
 	};
 	/** Legal-clock time segments used for deadline and pause calculations. */
 	readonly clockSegments: {
@@ -293,6 +298,84 @@ export const makeMinimalPersistence = (): Effect.Effect<MinimalPersistence> =>
 						yield* Ref.update(auditEventsRef, (arr) => [...arr, record]);
 						return record;
 					}),
+				list: (input: Record<string, unknown>) =>
+					Ref.get(auditEventsRef).pipe(
+						Effect.map((arr) => {
+							const limit = Math.max(
+								1,
+								Math.min(500, (input.limit as number | undefined) ?? 50)
+							);
+							const requestIds = Array.isArray(input.requestIds)
+								? new Set(input.requestIds as readonly string[])
+								: undefined;
+							const cursor = input.cursor as
+								| { readonly createdAt: string; readonly id: string }
+								| undefined;
+							const filtered = arr
+								.filter((event) =>
+									input.requestId ? event.requestId === input.requestId : true
+								)
+								.filter((event) =>
+									requestIds
+										? typeof event.requestId === "string" &&
+											requestIds.has(event.requestId)
+										: true
+								)
+								.filter((event) =>
+									input.actor ? event.actor === input.actor : true
+								)
+								.filter((event) =>
+									input.action ? event.action === input.action : true
+								)
+								.filter((event) =>
+									input.createdAfter
+										? typeof event.createdAt === "string" &&
+											event.createdAt >= (input.createdAfter as string)
+										: true
+								)
+								.filter((event) =>
+									input.createdBefore
+										? typeof event.createdAt === "string" &&
+											event.createdAt <= (input.createdBefore as string)
+										: true
+								)
+								.filter((event) => {
+									if (!cursor) {
+										return true;
+									}
+									const createdAt =
+										typeof event.createdAt === "string" ? event.createdAt : "";
+									const id = typeof event.id === "string" ? event.id : "";
+									return (
+										createdAt < cursor.createdAt ||
+										(createdAt === cursor.createdAt && id < cursor.id)
+									);
+								})
+								.toSorted((left, right) => {
+									const leftCreatedAt =
+										typeof left.createdAt === "string" ? left.createdAt : "";
+									const rightCreatedAt =
+										typeof right.createdAt === "string" ? right.createdAt : "";
+									const order = rightCreatedAt.localeCompare(leftCreatedAt);
+									if (order !== 0) {
+										return order;
+									}
+									const leftId = typeof left.id === "string" ? left.id : "";
+									const rightId = typeof right.id === "string" ? right.id : "";
+									return rightId.localeCompare(leftId);
+								});
+							const items = filtered.slice(0, limit);
+							const last = items.at(-1);
+							const nextCursor =
+								filtered.length > limit &&
+								last &&
+								typeof last.createdAt === "string" &&
+								typeof last.id === "string"
+									? { createdAt: last.createdAt, id: last.id }
+									: undefined;
+							return { items, limit, nextCursor };
+						})
+					),
 				listByRequestId: (requestId: string) =>
 					Ref.get(auditEventsRef).pipe(
 						Effect.map((arr) =>

--- a/packages/backend/src/testing/minimal-persistence.ts
+++ b/packages/backend/src/testing/minimal-persistence.ts
@@ -301,10 +301,7 @@ export const makeMinimalPersistence = (): Effect.Effect<MinimalPersistence> =>
 				list: (input: Record<string, unknown>) =>
 					Ref.get(auditEventsRef).pipe(
 						Effect.map((arr) => {
-							const limit = Math.max(
-								1,
-								Math.min(500, (input.limit as number | undefined) ?? 50)
-							);
+							const limit = boundedLimit(input.limit);
 							const requestIds = Array.isArray(input.requestIds)
 								? new Set(input.requestIds as readonly string[])
 								: undefined;

--- a/packages/backend/test/__snapshots__/openapi.test.ts.snap
+++ b/packages/backend/test/__snapshots__/openapi.test.ts.snap
@@ -564,6 +564,16 @@ exports[`openAPI and docs surface > keeps generated spec stable 1`] = `
                         "since": {
                           "type": "string",
                         },
+                        "tipHash": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                        },
                         "until": {
                           "anyOf": [
                             {

--- a/packages/backend/test/__snapshots__/openapi.test.ts.snap
+++ b/packages/backend/test/__snapshots__/openapi.test.ts.snap
@@ -39,6 +39,602 @@ exports[`openAPI and docs surface > keeps generated spec stable 1`] = `
   },
   "openapi": "3.1.0",
   "paths": {
+    "/audit": {
+      "get": {
+        "operationId": "audit_list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "actor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "type": "null",
+                },
+              ],
+            },
+          },
+          {
+            "in": "query",
+            "name": "created_after",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "type": "null",
+                },
+              ],
+            },
+          },
+          {
+            "in": "query",
+            "name": "created_before",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "type": "null",
+                },
+              ],
+            },
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "type": "null",
+                },
+              ],
+            },
+          },
+          {
+            "in": "query",
+            "name": "event_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "type": "null",
+                },
+              ],
+            },
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "type": "null",
+                },
+              ],
+            },
+          },
+          {
+            "in": "query",
+            "name": "request_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "type": "null",
+                },
+              ],
+            },
+          },
+          {
+            "in": "query",
+            "name": "subject_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "type": "null",
+                },
+              ],
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "items": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "action": {
+                                "type": "string",
+                              },
+                              "actor": {
+                                "type": "string",
+                              },
+                              "createdAt": {
+                                "type": "string",
+                              },
+                              "hash": {
+                                "type": "string",
+                              },
+                              "hashAlg": {
+                                "type": "string",
+                              },
+                              "id": {
+                                "type": "string",
+                              },
+                              "object": {
+                                "type": "string",
+                              },
+                              "prevHash": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                  },
+                                  {
+                                    "type": "null",
+                                  },
+                                ],
+                              },
+                              "requestId": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                  },
+                                  {
+                                    "type": "null",
+                                  },
+                                ],
+                              },
+                              "sequence": {
+                                "anyOf": [
+                                  {
+                                    "type": "number",
+                                  },
+                                  {
+                                    "enum": [
+                                      "NaN",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  {
+                                    "enum": [
+                                      "Infinity",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  {
+                                    "enum": [
+                                      "-Infinity",
+                                    ],
+                                    "type": "string",
+                                  },
+                                ],
+                              },
+                            },
+                            "required": [
+                              "action",
+                              "actor",
+                              "createdAt",
+                              "hash",
+                              "hashAlg",
+                              "id",
+                              "object",
+                              "sequence",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                        "pagination": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "limit": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                },
+                                {
+                                  "enum": [
+                                    "NaN",
+                                  ],
+                                  "type": "string",
+                                },
+                                {
+                                  "enum": [
+                                    "Infinity",
+                                  ],
+                                  "type": "string",
+                                },
+                                {
+                                  "enum": [
+                                    "-Infinity",
+                                  ],
+                                  "type": "string",
+                                },
+                              ],
+                            },
+                            "nextCursor": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                            },
+                          },
+                          "required": [
+                            "limit",
+                          ],
+                          "type": "object",
+                        },
+                      },
+                      "required": [
+                        "items",
+                        "pagination",
+                      ],
+                      "type": "object",
+                    },
+                    "meta": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": {
+                            "type": "null",
+                          },
+                          "type": "object",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                    },
+                    "ok": {
+                      "enum": [
+                        true,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "data",
+                    "ok",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Success",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/effect_HttpApiSchemaError",
+                },
+              },
+            },
+            "description": "The request or response did not match the expected schema",
+          },
+        },
+        "security": [
+          {
+            "BearerAuth": [],
+          },
+        ],
+        "summary": "List audit events",
+        "tags": [
+          "audit",
+        ],
+      },
+    },
+    "/audit/export": {
+      "get": {
+        "operationId": "audit_export",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "enum": [
+                        "jsonl",
+                      ],
+                      "type": "string",
+                    },
+                    {
+                      "enum": [
+                        "csv",
+                      ],
+                      "type": "string",
+                    },
+                  ],
+                },
+                {
+                  "type": "null",
+                },
+              ],
+            },
+          },
+          {
+            "in": "query",
+            "name": "since",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "until",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "type": "null",
+                },
+              ],
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "eventCount": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                            },
+                            {
+                              "enum": [
+                                "NaN",
+                              ],
+                              "type": "string",
+                            },
+                            {
+                              "enum": [
+                                "Infinity",
+                              ],
+                              "type": "string",
+                            },
+                            {
+                              "enum": [
+                                "-Infinity",
+                              ],
+                              "type": "string",
+                            },
+                          ],
+                        },
+                        "events": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "actor": {
+                                "type": "string",
+                              },
+                              "eventType": {
+                                "type": "string",
+                              },
+                              "hash": {
+                                "type": "string",
+                              },
+                              "hashAlg": {
+                                "type": "string",
+                              },
+                              "id": {
+                                "type": "string",
+                              },
+                              "metadata": {
+                                "additionalProperties": {
+                                  "type": "null",
+                                },
+                                "type": "object",
+                              },
+                              "occurredAt": {
+                                "type": "string",
+                              },
+                              "prevHash": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                  },
+                                  {
+                                    "type": "null",
+                                  },
+                                ],
+                              },
+                              "requestId": {
+                                "type": "string",
+                              },
+                              "sequence": {
+                                "anyOf": [
+                                  {
+                                    "type": "number",
+                                  },
+                                  {
+                                    "enum": [
+                                      "NaN",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  {
+                                    "enum": [
+                                      "Infinity",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  {
+                                    "enum": [
+                                      "-Infinity",
+                                    ],
+                                    "type": "string",
+                                  },
+                                ],
+                              },
+                            },
+                            "required": [
+                              "actor",
+                              "eventType",
+                              "hash",
+                              "hashAlg",
+                              "id",
+                              "metadata",
+                              "occurredAt",
+                              "requestId",
+                              "sequence",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                        "format": {
+                          "anyOf": [
+                            {
+                              "enum": [
+                                "jsonl",
+                              ],
+                              "type": "string",
+                            },
+                            {
+                              "enum": [
+                                "csv",
+                              ],
+                              "type": "string",
+                            },
+                          ],
+                        },
+                        "rootHash": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                        },
+                        "since": {
+                          "type": "string",
+                        },
+                        "until": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                        },
+                      },
+                      "required": [
+                        "eventCount",
+                        "events",
+                        "format",
+                        "since",
+                      ],
+                      "type": "object",
+                    },
+                    "meta": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": {
+                            "type": "null",
+                          },
+                          "type": "object",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                    },
+                    "ok": {
+                      "enum": [
+                        true,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "data",
+                    "ok",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Success",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/effect_HttpApiSchemaError",
+                },
+              },
+            },
+            "description": "The request or response did not match the expected schema",
+          },
+        },
+        "security": [
+          {
+            "BearerAuth": [],
+          },
+        ],
+        "summary": "Export tenant audit trail",
+        "tags": [
+          "audit",
+        ],
+      },
+    },
     "/init": {
       "post": {
         "operationId": "init_runtime",
@@ -10410,6 +11006,9 @@ exports[`openAPI and docs surface > keeps generated spec stable 1`] = `
     },
     {
       "name": "subjects",
+    },
+    {
+      "name": "audit",
     },
     {
       "name": "policies",

--- a/packages/backend/test/e2e/fixtures.ts
+++ b/packages/backend/test/e2e/fixtures.ts
@@ -12,6 +12,7 @@ import type {
 	CreateVerificationEvidenceInput,
 	FulfillmentArtifactRecord,
 	JsonValue,
+	ListAuditEventsInput,
 	ListRequestsBySubjectInput,
 	NotificationDeliveryAttemptRecord,
 	NotificationEventRecord,
@@ -155,6 +156,53 @@ export const makeMemoryPersistence = (): PersistenceService => {
 				};
 				auditEvents.push(record);
 				return Effect.succeed(record);
+			},
+			list: (input: ListAuditEventsInput) => {
+				const limit = Math.max(1, Math.min(500, input.limit ?? 50));
+				const requestIdSet = input.requestIds
+					? new Set(input.requestIds)
+					: undefined;
+				const filtered = auditEvents
+					.filter((event) =>
+						input.requestId ? event.requestId === input.requestId : true
+					)
+					.filter((event) =>
+						requestIdSet
+							? event.requestId !== undefined &&
+								requestIdSet.has(event.requestId)
+							: true
+					)
+					.filter((event) => (input.actor ? event.actor === input.actor : true))
+					.filter((event) =>
+						input.action ? event.action === input.action : true
+					)
+					.filter((event) =>
+						input.createdAfter ? event.createdAt >= input.createdAfter : true
+					)
+					.filter((event) =>
+						input.createdBefore ? event.createdAt <= input.createdBefore : true
+					)
+					.filter((event) =>
+						input.cursor
+							? event.createdAt < input.cursor.createdAt ||
+								(event.createdAt === input.cursor.createdAt &&
+									event.id < input.cursor.id)
+							: true
+					)
+					.toSorted((left, right) => {
+						const order = right.createdAt.localeCompare(left.createdAt);
+						return order === 0 ? right.id.localeCompare(left.id) : order;
+					});
+				const items = filtered.slice(0, limit);
+				const last = items.at(-1);
+				return Effect.succeed({
+					items,
+					limit,
+					nextCursor:
+						filtered.length > limit && last
+							? { createdAt: last.createdAt, id: last.id }
+							: undefined,
+				});
 			},
 			listByRequestId: (requestId: string) =>
 				Effect.succeed(

--- a/packages/backend/test/e2e/tenant-isolation.test.ts
+++ b/packages/backend/test/e2e/tenant-isolation.test.ts
@@ -16,6 +16,7 @@ import type {
 	CreateVerificationEvidenceInput,
 	FulfillmentArtifactRecord,
 	JsonValue,
+	ListAuditEventsInput,
 	NotificationDeliveryAttemptRecord,
 	NotificationEventRecord,
 	PaginationInput,
@@ -171,6 +172,60 @@ const makeTenantScopedMemoryPersistence = (): PersistenceService => {
 					};
 					auditEvents.push(record);
 					return record;
+				}),
+			list: (input: ListAuditEventsInput) =>
+				Effect.gen(function* listAllAuditEvents() {
+					const tenantId = yield* currentTenantId;
+					const limit = Math.max(1, Math.min(500, input.limit ?? 50));
+					const requestIdSet = input.requestIds
+						? new Set(input.requestIds)
+						: undefined;
+					const filtered = auditEvents
+						.filter((event) => event.tenantId === tenantId)
+						.filter((event) =>
+							input.requestId ? event.requestId === input.requestId : true
+						)
+						.filter((event) =>
+							requestIdSet
+								? event.requestId !== undefined &&
+									requestIdSet.has(event.requestId)
+								: true
+						)
+						.filter((event) =>
+							input.actor ? event.actor === input.actor : true
+						)
+						.filter((event) =>
+							input.action ? event.action === input.action : true
+						)
+						.filter((event) =>
+							input.createdAfter ? event.createdAt >= input.createdAfter : true
+						)
+						.filter((event) =>
+							input.createdBefore
+								? event.createdAt <= input.createdBefore
+								: true
+						)
+						.filter((event) =>
+							input.cursor
+								? event.createdAt < input.cursor.createdAt ||
+									(event.createdAt === input.cursor.createdAt &&
+										event.id < input.cursor.id)
+								: true
+						)
+						.toSorted((left, right) => {
+							const order = right.createdAt.localeCompare(left.createdAt);
+							return order === 0 ? right.id.localeCompare(left.id) : order;
+						});
+					const items = filtered.slice(0, limit);
+					const last = items.at(-1);
+					return {
+						items,
+						limit,
+						nextCursor:
+							filtered.length > limit && last
+								? { createdAt: last.createdAt, id: last.id }
+								: undefined,
+					};
 				}),
 			listByRequestId: (requestId: string) =>
 				Effect.gen(function* listAuditEvents() {
@@ -1386,6 +1441,18 @@ const makeRouteProbes = (): readonly RouteProbe[] => [
 		key: "POST /policies/upgrades/:proposalId/apply",
 		method: "POST",
 		path: "/policies/upgrades/proposal-tenant-b/apply",
+	},
+	{
+		headers: tenantAHeaders,
+		key: "GET /audit",
+		method: "GET",
+		path: "/audit",
+	},
+	{
+		headers: tenantAHeaders,
+		key: "GET /audit/export",
+		method: "GET",
+		path: "/audit/export?since=1970-01-01T00:00:00.000Z&format=jsonl",
 	},
 	{
 		key: "GET /status",

--- a/packages/backend/test/routes/audit.test.ts
+++ b/packages/backend/test/routes/audit.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { dsarInstance } from "../../src";
+import {
+	TEST_MEMBER_HEADERS,
+	TEST_RUNTIME_AUTH,
+	TEST_SUBJECT_HEADERS,
+} from "../auth";
+import { makeMemoryPersistence } from "../e2e/fixtures";
+
+interface ListEnvelope {
+	readonly data: {
+		readonly items: readonly {
+			readonly id: string;
+			readonly action: string;
+			readonly actor: string;
+			readonly requestId?: string;
+		}[];
+		readonly pagination: {
+			readonly limit: number;
+			readonly nextCursor?: string;
+		};
+	};
+}
+
+interface ExportEnvelope {
+	readonly data: {
+		readonly events: readonly { readonly id: string }[];
+		readonly format: "jsonl" | "csv";
+		readonly since: string;
+		readonly until?: string;
+		readonly rootHash?: string;
+		readonly eventCount: number;
+	};
+}
+
+const makeRuntime = () => {
+	const persistence = makeMemoryPersistence();
+	const runtime = dsarInstance({
+		...TEST_RUNTIME_AUTH,
+		adapters: {
+			inbound: "stub",
+			notifications: "stub",
+			storage: "stub",
+		},
+		repos: { persistence },
+	});
+	return { persistence, runtime };
+};
+
+const seedAudit = async (
+	persistence: ReturnType<typeof makeMemoryPersistence>,
+	events: readonly {
+		readonly id: string;
+		readonly action: string;
+		readonly actor: string;
+		readonly createdAt: string;
+		readonly requestId?: string;
+		readonly sequence: number;
+	}[]
+): Promise<void> => {
+	for (const event of events) {
+		const append = persistence.auditEvents.append({
+			action: event.action,
+			actor: event.actor,
+			after: {},
+			before: {},
+			createdAt: event.createdAt,
+			hash: `hash-${event.id}`,
+			hashAlg: "sha256",
+			id: event.id,
+			object: "request",
+			reason: {},
+			requestId: event.requestId,
+			sequence: event.sequence,
+		});
+		// Memory persistence's append returns Effect.succeed synchronously.
+		// Tests don't drive the Effect runtime, so we manually invoke it.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		await (append as unknown as Promise<unknown>);
+	}
+};
+
+describe("audit routes", () => {
+	it("GET /audit returns paginated tenant-scoped events newest-first", async () => {
+		const { persistence, runtime } = makeRuntime();
+		await seedAudit(persistence, [
+			{
+				action: "capture",
+				actor: "operator-1",
+				createdAt: "2026-01-01T00:00:00.000Z",
+				id: "evt-1",
+				requestId: "req-1",
+				sequence: 1,
+			},
+			{
+				action: "verify",
+				actor: "operator-2",
+				createdAt: "2026-01-02T00:00:00.000Z",
+				id: "evt-2",
+				requestId: "req-1",
+				sequence: 2,
+			},
+		]);
+		const response = await runtime.handler(
+			new Request("https://example.test/audit?limit=10", {
+				headers: TEST_MEMBER_HEADERS,
+				method: "GET",
+			})
+		);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as ListEnvelope;
+		expect(body.data.items.map((item) => item.id)).toStrictEqual([
+			"evt-2",
+			"evt-1",
+		]);
+	});
+
+	it("GET /audit filters by event_type and actor", async () => {
+		const { persistence, runtime } = makeRuntime();
+		await seedAudit(persistence, [
+			{
+				action: "capture",
+				actor: "operator-1",
+				createdAt: "2026-01-01T00:00:00.000Z",
+				id: "evt-1",
+				requestId: "req-1",
+				sequence: 1,
+			},
+			{
+				action: "verify",
+				actor: "operator-2",
+				createdAt: "2026-01-02T00:00:00.000Z",
+				id: "evt-2",
+				requestId: "req-1",
+				sequence: 2,
+			},
+		]);
+		const response = await runtime.handler(
+			new Request(
+				"https://example.test/audit?event_type=verify&actor=operator-2",
+				{
+					headers: TEST_MEMBER_HEADERS,
+					method: "GET",
+				}
+			)
+		);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as ListEnvelope;
+		expect(body.data.items.map((item) => item.id)).toStrictEqual(["evt-2"]);
+	});
+
+	it("GET /audit rejects subject principals", async () => {
+		const { runtime } = makeRuntime();
+		const response = await runtime.handler(
+			new Request("https://example.test/audit", {
+				headers: TEST_SUBJECT_HEADERS,
+				method: "GET",
+			})
+		);
+		expect(response.status).toBe(403);
+	});
+
+	it("GET /audit rejects malformed cursors", async () => {
+		const { runtime } = makeRuntime();
+		const response = await runtime.handler(
+			new Request("https://example.test/audit?cursor=not-base64", {
+				headers: TEST_MEMBER_HEADERS,
+				method: "GET",
+			})
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("GET /audit/export requires `since`", async () => {
+		const { runtime } = makeRuntime();
+		const response = await runtime.handler(
+			new Request("https://example.test/audit/export", {
+				headers: TEST_MEMBER_HEADERS,
+				method: "GET",
+			})
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("GET /audit/export returns events in the time window", async () => {
+		const { persistence, runtime } = makeRuntime();
+		await seedAudit(persistence, [
+			{
+				action: "capture",
+				actor: "operator-1",
+				createdAt: "2025-12-31T00:00:00.000Z",
+				id: "evt-0",
+				sequence: 0,
+			},
+			{
+				action: "verify",
+				actor: "operator-1",
+				createdAt: "2026-01-15T00:00:00.000Z",
+				id: "evt-1",
+				sequence: 1,
+			},
+			{
+				action: "fulfil",
+				actor: "operator-1",
+				createdAt: "2026-02-15T00:00:00.000Z",
+				id: "evt-2",
+				sequence: 2,
+			},
+		]);
+		const response = await runtime.handler(
+			new Request(
+				"https://example.test/audit/export?since=2026-01-01T00:00:00.000Z&until=2026-02-01T00:00:00.000Z&format=jsonl",
+				{
+					headers: TEST_MEMBER_HEADERS,
+					method: "GET",
+				}
+			)
+		);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as ExportEnvelope;
+		expect(body.data.eventCount).toBe(1);
+		expect(body.data.events.map((event) => event.id)).toStrictEqual(["evt-1"]);
+		expect(body.data.format).toBe("jsonl");
+	});
+
+	it("GET /audit/export rejects subject principals", async () => {
+		const { runtime } = makeRuntime();
+		const response = await runtime.handler(
+			new Request(
+				"https://example.test/audit/export?since=2026-01-01T00:00:00.000Z",
+				{
+					headers: TEST_SUBJECT_HEADERS,
+					method: "GET",
+				}
+			)
+		);
+		expect(response.status).toBe(403);
+	});
+});

--- a/packages/backend/test/routes/audit.test.ts
+++ b/packages/backend/test/routes/audit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
 
 import { dsarInstance } from "../../src";
 import {
@@ -30,6 +31,7 @@ interface ExportEnvelope {
 		readonly since: string;
 		readonly until?: string;
 		readonly rootHash?: string;
+		readonly tipHash?: string;
 		readonly eventCount: number;
 	};
 }
@@ -60,24 +62,22 @@ const seedAudit = async (
 	}[]
 ): Promise<void> => {
 	for (const event of events) {
-		const append = persistence.auditEvents.append({
-			action: event.action,
-			actor: event.actor,
-			after: {},
-			before: {},
-			createdAt: event.createdAt,
-			hash: `hash-${event.id}`,
-			hashAlg: "sha256",
-			id: event.id,
-			object: "request",
-			reason: {},
-			requestId: event.requestId,
-			sequence: event.sequence,
-		});
-		// Memory persistence's append returns Effect.succeed synchronously.
-		// Tests don't drive the Effect runtime, so we manually invoke it.
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		await (append as unknown as Promise<unknown>);
+		await Effect.runPromise(
+			persistence.auditEvents.append({
+				action: event.action,
+				actor: event.actor,
+				after: {},
+				before: {},
+				createdAt: event.createdAt,
+				hash: `hash-${event.id}`,
+				hashAlg: "sha256",
+				id: event.id,
+				object: "request",
+				reason: {},
+				requestId: event.requestId,
+				sequence: event.sequence,
+			})
+		);
 	}
 };
 

--- a/packages/cli/src/commands/audit-tail.ts
+++ b/packages/cli/src/commands/audit-tail.ts
@@ -1,0 +1,194 @@
+/* oxlint-disable max-statements, promise/avoid-new, promise/no-multiple-resolved */
+import type {
+	ApiClient,
+	CommandDefinition,
+	CommandExecutionContext,
+} from "../types";
+
+const DEFAULT_INTERVAL_MS = 2000;
+const POLL_PAGE_SIZE = 200;
+
+interface AuditTailEvent {
+	readonly id: string;
+	readonly action: string;
+	readonly actor: string;
+	readonly createdAt: string;
+	readonly object: string;
+	readonly requestId?: string;
+	readonly sequence: number;
+}
+
+interface AuditListEnvelope {
+	readonly data?: {
+		readonly items?: readonly AuditTailEvent[];
+		readonly pagination?: {
+			readonly limit: number;
+			readonly nextCursor?: string;
+		};
+	};
+}
+
+const requireFlag = (
+	flags: Readonly<Record<string, string>>,
+	key: string,
+	message: string
+): string => {
+	const value = flags[key];
+	if (!value) {
+		throw new Error(message);
+	}
+	return value;
+};
+
+const parseIntegerFlag = (
+	flags: Readonly<Record<string, string>>,
+	key: string,
+	fallback: number
+): number => {
+	const raw = flags[key];
+	if (!raw) {
+		return fallback;
+	}
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		throw new Error(`Invalid --${key}: must be a positive integer.`);
+	}
+	return parsed;
+};
+
+const sleep = (ms: number, signal: AbortSignal): Promise<void> => {
+	if (signal.aborted) {
+		return Promise.resolve();
+	}
+	return new Promise<void>((resolve) => {
+		const state: { settled: boolean; timer?: ReturnType<typeof setTimeout> } = {
+			settled: false,
+		};
+		const finish = () => {
+			if (state.settled) {
+				return;
+			}
+			state.settled = true;
+			signal.removeEventListener("abort", finish);
+			if (state.timer !== undefined) {
+				clearTimeout(state.timer);
+			}
+			resolve();
+		};
+		state.timer = setTimeout(finish, ms);
+		signal.addEventListener("abort", finish, { once: true });
+	});
+};
+
+const formatLine = (event: AuditTailEvent, output: "json" | "text"): string => {
+	if (output === "json") {
+		return JSON.stringify(event);
+	}
+	return `[${event.createdAt}] ${event.actor} ${event.action} ${event.object}${
+		event.requestId ? ` request=${event.requestId}` : ""
+	}`;
+};
+
+const pollOnce = async (
+	api: ApiClient,
+	requestId: string,
+	createdAfter: string | undefined,
+	limit: number
+): Promise<readonly AuditTailEvent[]> => {
+	const response = (await api.invoke({
+		method: "GET",
+		path: "/audit",
+		query: {
+			created_after: createdAfter,
+			limit: String(limit),
+			request_id: requestId,
+		},
+	})) as AuditListEnvelope;
+	const items = response.data?.items ?? [];
+	return [...items].toSorted((left, right) => {
+		const order = left.createdAt.localeCompare(right.createdAt);
+		return order === 0 ? left.sequence - right.sequence : order;
+	});
+};
+
+/**
+ * Runs the `dsar audit tail` polling loop, emitting newly-observed events
+ * to {@link CommandExecutionContext.writeLine} until cancelled.
+ *
+ * Exits cleanly when:
+ *   - `signal` aborts (SIGINT in production, AbortController in tests), or
+ *   - `--max-polls=<n>` reached (test-only bound).
+ */
+export const runAuditTailLoop = async (
+	ctx: CommandExecutionContext,
+	signal: AbortSignal
+): Promise<{
+	readonly polls: number;
+	readonly emitted: number;
+	readonly requestId: string;
+}> => {
+	const requestId = requireFlag(
+		ctx.input.flags,
+		"request",
+		"Missing required --request for audit tail command."
+	);
+	const intervalMs = parseIntegerFlag(
+		ctx.input.flags,
+		"interval",
+		DEFAULT_INTERVAL_MS
+	);
+	const maxPolls = ctx.input.flags["max-polls"]
+		? parseIntegerFlag(ctx.input.flags, "max-polls", 0)
+		: Number.POSITIVE_INFINITY;
+	const outputMode = ctx.input.global.output;
+	const seen = new Set<string>();
+	let createdAfter: string | undefined;
+	let polls = 0;
+	let emitted = 0;
+	while (!signal.aborted && polls < maxPolls) {
+		polls += 1;
+		const events = await pollOnce(
+			ctx.api,
+			requestId,
+			createdAfter,
+			POLL_PAGE_SIZE
+		);
+		for (const event of events) {
+			if (seen.has(event.id)) {
+				continue;
+			}
+			seen.add(event.id);
+			ctx.writeLine(formatLine(event, outputMode));
+			emitted += 1;
+			if (createdAfter === undefined || event.createdAt > createdAfter) {
+				createdAfter = event.createdAt;
+			}
+		}
+		if (polls >= maxPolls || signal.aborted) {
+			break;
+		}
+		await sleep(intervalMs, signal);
+	}
+	return { emitted, polls, requestId };
+};
+
+/**
+ * `dsar audit tail --request=<id>` — polls the audit log endpoint and
+ * streams newly-observed events to stdout. Exits on SIGINT.
+ */
+export const auditTailCommand: CommandDefinition = {
+	description:
+		"Stream audit events for a request, polling the audit log endpoint.",
+	execute: async (ctx) => {
+		const controller = new AbortController();
+		const onInterrupt = () => controller.abort();
+		process.once("SIGINT", onInterrupt);
+		try {
+			return await runAuditTailLoop(ctx, controller.signal);
+		} finally {
+			process.removeListener("SIGINT", onInterrupt);
+		}
+	},
+	id: "audit_tail",
+	usage: ["audit", "tail"],
+};

--- a/packages/cli/src/commands/audit-tail.ts
+++ b/packages/cli/src/commands/audit-tail.ts
@@ -28,6 +28,8 @@ interface AuditListEnvelope {
 	};
 }
 
+const POLL_DRAIN_PAGE_CAP = 50;
+
 const requireFlag = (
 	flags: Readonly<Record<string, string>>,
 	key: string,
@@ -89,23 +91,43 @@ const formatLine = (event: AuditTailEvent, output: "json" | "text"): string => {
 	}`;
 };
 
+/**
+ * Drains every page of `/audit` matching the current `created_after`
+ * watermark, returning events in ascending creation order. Following
+ * `nextCursor` here is what prevents a burst larger than
+ * {@link POLL_PAGE_SIZE} from silently dropping the older tail of the
+ * burst on the next iteration (the watermark would otherwise jump over
+ * unseen events).
+ */
 const pollOnce = async (
 	api: ApiClient,
 	requestId: string,
 	createdAfter: string | undefined,
 	limit: number
 ): Promise<readonly AuditTailEvent[]> => {
-	const response = (await api.invoke({
-		method: "GET",
-		path: "/audit",
-		query: {
-			created_after: createdAfter,
-			limit: String(limit),
-			request_id: requestId,
-		},
-	})) as AuditListEnvelope;
-	const items = response.data?.items ?? [];
-	return [...items].toSorted((left, right) => {
+	const collected: AuditTailEvent[] = [];
+	let cursor: string | undefined;
+	let pages = 0;
+	do {
+		const response = (await api.invoke({
+			method: "GET",
+			path: "/audit",
+			query: {
+				created_after: createdAfter,
+				cursor,
+				limit: String(limit),
+				request_id: requestId,
+			},
+		})) as AuditListEnvelope;
+		const items = response.data?.items ?? [];
+		collected.push(...items);
+		cursor = response.data?.pagination?.nextCursor;
+		pages += 1;
+		if (pages >= POLL_DRAIN_PAGE_CAP) {
+			break;
+		}
+	} while (cursor);
+	return collected.toSorted((left, right) => {
 		const order = left.createdAt.localeCompare(right.createdAt);
 		return order === 0 ? left.sequence - right.sequence : order;
 	});
@@ -118,6 +140,15 @@ const pollOnce = async (
  * Exits cleanly when:
  *   - `signal` aborts (SIGINT in production, AbortController in tests), or
  *   - `--max-polls=<n>` reached (test-only bound).
+ *
+ * @param ctx - Command execution context carrying parsed flags, the API
+ *   client used to invoke `/audit`, and the writeLine sink for emitted
+ *   events.
+ * @param signal - Abort signal used to stop polling gracefully (wired to
+ *   SIGINT at the binary entry point, or to a test-controlled
+ *   `AbortController` from unit tests).
+ * @returns A summary of the run: the number of `polls` performed, the
+ *   count of unique events `emitted`, and the `requestId` that was tailed.
  */
 export const runAuditTailLoop = async (
 	ctx: CommandExecutionContext,
@@ -141,7 +172,12 @@ export const runAuditTailLoop = async (
 		? parseIntegerFlag(ctx.input.flags, "max-polls", 0)
 		: Number.POSITIVE_INFINITY;
 	const outputMode = ctx.input.global.output;
-	const seen = new Set<string>();
+	// `seen` is bounded by the backend `created_after` filter: once the
+	// watermark advances past a timestamp, events at strictly older
+	// timestamps cannot reappear, so we only need to retain ids that share
+	// the current watermark for cross-poll dedup. Without this bound, a
+	// long tail session would grow `seen` indefinitely.
+	let seenAtWatermark = new Set<string>();
 	let createdAfter: string | undefined;
 	let polls = 0;
 	let emitted = 0;
@@ -154,14 +190,16 @@ export const runAuditTailLoop = async (
 			POLL_PAGE_SIZE
 		);
 		for (const event of events) {
-			if (seen.has(event.id)) {
+			if (seenAtWatermark.has(event.id)) {
 				continue;
 			}
-			seen.add(event.id);
 			ctx.writeLine(formatLine(event, outputMode));
 			emitted += 1;
 			if (createdAfter === undefined || event.createdAt > createdAfter) {
 				createdAfter = event.createdAt;
+				seenAtWatermark = new Set<string>([event.id]);
+			} else {
+				seenAtWatermark.add(event.id);
 			}
 		}
 		if (polls >= maxPolls || signal.aborted) {

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -2,9 +2,12 @@ import { makeRouteCommands } from "../commands/factory";
 
 /**
  * CLI commands for audit-trail operations: exporting event chains
- * and verifying hash-chain integrity.
+ * and verifying hash-chain integrity, plus tenant-wide list and export
+ * for compliance review.
  */
 export const auditCommands = makeRouteCommands([
 	"requests_audit_export",
 	"requests_audit_verify",
+	"audit_list",
+	"audit_export",
 ] as const);

--- a/packages/cli/src/commands/helpers.ts
+++ b/packages/cli/src/commands/helpers.ts
@@ -156,6 +156,29 @@ const queryForRoute = (
 			format: input.flags.format,
 		};
 	}
+	if (route.id === "audit_list") {
+		return {
+			actor: input.flags.actor,
+			created_after: input.flags["created-after"] ?? input.flags.since,
+			created_before: input.flags["created-before"] ?? input.flags.until,
+			cursor: input.flags.cursor,
+			event_type: input.flags["event-type"],
+			limit: input.flags.limit,
+			request_id: input.flags["request-id"],
+			subject_id: input.flags["subject-id"],
+		};
+	}
+	if (route.id === "audit_export") {
+		return {
+			format: input.flags.format,
+			since: requireFlag(
+				input.flags,
+				"since",
+				"Missing required --since for audit export command."
+			),
+			until: input.flags.until,
+		};
+	}
 	if (route.id === "requests_manifest_artifact_download") {
 		return {
 			key: requireFlag(

--- a/packages/cli/src/commands/registry.ts
+++ b/packages/cli/src/commands/registry.ts
@@ -1,4 +1,5 @@
 import { auditCommands } from "../commands/audit";
+import { auditTailCommand } from "../commands/audit-tail";
 import { matchCommand } from "../commands/helpers";
 import { notificationCommands } from "../commands/notifications";
 import { policiesCommands } from "../commands/policies";
@@ -17,6 +18,7 @@ const commandGroups: readonly CommandDefinition[] = [
 	...webhooksCommands,
 	...retentionCommands,
 	...auditCommands,
+	auditTailCommand,
 	...notificationCommands,
 ];
 

--- a/packages/cli/src/parity/route-map.ts
+++ b/packages/cli/src/parity/route-map.ts
@@ -405,6 +405,20 @@ export const routeParityMap: readonly RouteParityDefinition[] = [
 		method: "POST",
 		path: "/requests/{id}/audit/verify",
 	},
+	{
+		command: ["audit", "list"],
+		description: "List audit events with filters.",
+		id: "audit_list",
+		method: "GET",
+		path: "/audit",
+	},
+	{
+		command: ["audit", "export"],
+		description: "Export tenant audit trail.",
+		id: "audit_export",
+		method: "GET",
+		path: "/audit/export",
+	},
 ] as const;
 
 /**

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -164,6 +164,7 @@ export const runCli = async (options: CliRunOptions): Promise<number> => {
 						api,
 						input,
 						params: matched.params,
+						writeLine: stdout,
 					}),
 			})
 		);

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -86,6 +86,8 @@ export interface CommandExecutionContext {
 	readonly api: ApiClient;
 	/** Route/path params extracted from command syntax. */
 	readonly params: Readonly<Record<string, string>>;
+	/** Direct stdout sink for streaming commands (e.g. `audit tail`). */
+	readonly writeLine: (line: string) => void;
 }
 
 /**

--- a/packages/cli/test/audit-tail.test.ts
+++ b/packages/cli/test/audit-tail.test.ts
@@ -97,6 +97,67 @@ describe("audit tail polling loop", () => {
 		expect(calls[1]?.query?.created_after).toBe("2026-01-01T00:00:00.000Z");
 	});
 
+	it("drains every audit page within a single poll before advancing the watermark", async () => {
+		const calls: ApiRequest[] = [];
+		const lines: string[] = [];
+		const pages = [
+			{
+				items: [
+					{
+						action: "capture",
+						actor: "operator-1",
+						createdAt: "2026-01-01T00:00:00.000Z",
+						id: "evt-1",
+						object: "request",
+						sequence: 1,
+					},
+				],
+				nextCursor: "cursor-1",
+			},
+			{
+				items: [
+					{
+						action: "verify",
+						actor: "operator-1",
+						createdAt: "2026-01-02T00:00:00.000Z",
+						id: "evt-2",
+						object: "request",
+						sequence: 2,
+					},
+				],
+				nextCursor: undefined,
+			},
+		];
+		let pageIndex = 0;
+		const ctx = makeContext({
+			flags: {
+				interval: "1",
+				"max-polls": "1",
+				request: "req-1",
+			},
+			invoke: (request) => {
+				calls.push(request);
+				const page = pages[pageIndex] ?? {
+					items: [],
+					nextCursor: undefined,
+				};
+				pageIndex += 1;
+				return Promise.resolve({
+					data: {
+						items: page.items,
+						pagination: { limit: 200, nextCursor: page.nextCursor },
+					},
+				});
+			},
+			writeLine: (line) => lines.push(line),
+		});
+		const result = await runAuditTailLoop(ctx, new AbortController().signal);
+		expect(result.polls).toBe(1);
+		expect(result.emitted).toBe(2);
+		expect(calls).toHaveLength(2);
+		expect(calls[1]?.query?.cursor).toBe("cursor-1");
+	});
+
 	it("deduplicates events seen across overlapping polls", async () => {
 		const lines: string[] = [];
 		let pollIndex = 0;

--- a/packages/cli/test/audit-tail.test.ts
+++ b/packages/cli/test/audit-tail.test.ts
@@ -1,0 +1,199 @@
+/* oxlint-disable jest/no-conditional-in-test -- test helpers branch on stub state. */
+import { describe, expect, it } from "@effect/vitest";
+
+import { runAuditTailLoop } from "#src/commands/audit-tail";
+import type {
+	ApiClient,
+	ApiRequest,
+	CommandExecutionContext,
+	GlobalCliConfig,
+} from "#src/types";
+
+const makeGlobal = (
+	override: Partial<GlobalCliConfig> = {}
+): GlobalCliConfig => ({
+	apiUrl: "https://example.test",
+	fetch,
+	output: "json",
+	...override,
+});
+
+const makeContext = (input: {
+	readonly flags: Readonly<Record<string, string>>;
+	readonly invoke: (request: ApiRequest) => Promise<unknown>;
+	readonly writeLine: (line: string) => void;
+	readonly globalOverride?: Partial<GlobalCliConfig>;
+}): CommandExecutionContext => ({
+	api: { invoke: input.invoke } as ApiClient,
+	input: {
+		commandTokens: ["audit", "tail"],
+		flags: input.flags,
+		global: makeGlobal(input.globalOverride),
+	},
+	params: {},
+	writeLine: input.writeLine,
+});
+
+describe("audit tail polling loop", () => {
+	it("streams events from successive pages and tracks last seen timestamp", async () => {
+		const calls: ApiRequest[] = [];
+		const lines: string[] = [];
+		const pages: readonly (readonly {
+			readonly id: string;
+			readonly action: string;
+			readonly actor: string;
+			readonly createdAt: string;
+			readonly object: string;
+			readonly sequence: number;
+		}[])[] = [
+			[
+				{
+					action: "capture",
+					actor: "operator-1",
+					createdAt: "2026-01-01T00:00:00.000Z",
+					id: "evt-1",
+					object: "request",
+					sequence: 1,
+				},
+			],
+			[
+				{
+					action: "verify",
+					actor: "operator-2",
+					createdAt: "2026-01-02T00:00:00.000Z",
+					id: "evt-2",
+					object: "request",
+					sequence: 2,
+				},
+			],
+		];
+		let pollIndex = 0;
+		const ctx = makeContext({
+			flags: {
+				interval: "1",
+				"max-polls": "2",
+				request: "req-1",
+			},
+			invoke: (request) => {
+				calls.push(request);
+				const items = pages[pollIndex] ?? [];
+				pollIndex += 1;
+				return Promise.resolve({
+					data: {
+						items,
+						pagination: { limit: 200 },
+					},
+				});
+			},
+			writeLine: (line) => lines.push(line),
+		});
+		const result = await runAuditTailLoop(ctx, new AbortController().signal);
+		expect(result.polls).toBe(2);
+		expect(result.emitted).toBe(2);
+		expect(lines.map((line) => JSON.parse(line).id)).toStrictEqual([
+			"evt-1",
+			"evt-2",
+		]);
+		expect(calls[1]?.query?.created_after).toBe("2026-01-01T00:00:00.000Z");
+	});
+
+	it("deduplicates events seen across overlapping polls", async () => {
+		const lines: string[] = [];
+		let pollIndex = 0;
+		const ctx = makeContext({
+			flags: {
+				interval: "1",
+				"max-polls": "2",
+				request: "req-1",
+			},
+			invoke: () => {
+				const duplicate = {
+					action: "capture",
+					actor: "operator-1",
+					createdAt: "2026-01-01T00:00:00.000Z",
+					id: "evt-1",
+					object: "request",
+					sequence: 1,
+				};
+				pollIndex += 1;
+				return Promise.resolve({
+					data: {
+						items: [duplicate],
+						pagination: { limit: 200 },
+					},
+				});
+			},
+			writeLine: (line) => lines.push(line),
+		});
+		const result = await runAuditTailLoop(ctx, new AbortController().signal);
+		expect(pollIndex).toBe(2);
+		expect(result.emitted).toBe(1);
+	});
+
+	it("aborts when the signal fires before the next poll", async () => {
+		const lines: string[] = [];
+		const controller = new AbortController();
+		const ctx = makeContext({
+			flags: {
+				interval: "10000",
+				"max-polls": "5",
+				request: "req-1",
+			},
+			invoke: () => {
+				controller.abort();
+				return Promise.resolve({
+					data: { items: [], pagination: { limit: 200 } },
+				});
+			},
+			writeLine: (line) => lines.push(line),
+		});
+		const result = await runAuditTailLoop(ctx, controller.signal);
+		expect(result.polls).toBe(1);
+	});
+
+	it("formats events as `[ts] actor action object` in text mode", async () => {
+		const lines: string[] = [];
+		const ctx = makeContext({
+			flags: {
+				"max-polls": "1",
+				request: "req-1",
+			},
+			globalOverride: { output: "text" },
+			invoke: () =>
+				Promise.resolve({
+					data: {
+						items: [
+							{
+								action: "verify",
+								actor: "operator-1",
+								createdAt: "2026-01-01T00:00:00.000Z",
+								id: "evt-1",
+								object: "request",
+								requestId: "req-1",
+								sequence: 1,
+							},
+						],
+						pagination: { limit: 200 },
+					},
+				}),
+			writeLine: (line) => lines.push(line),
+		});
+		await runAuditTailLoop(ctx, new AbortController().signal);
+		expect(lines[0]).toBe(
+			"[2026-01-01T00:00:00.000Z] operator-1 verify request request=req-1"
+		);
+	});
+
+	it("requires --request", async () => {
+		const ctx = makeContext({
+			flags: {},
+			invoke: () => Promise.resolve({ data: { items: [] } }),
+			writeLine: () => {
+				// no-op
+			},
+		});
+		await expect(
+			runAuditTailLoop(ctx, new AbortController().signal)
+		).rejects.toThrow(/--request/);
+	});
+});

--- a/packages/cli/test/e2e/commands.e2e.test.ts
+++ b/packages/cli/test/e2e/commands.e2e.test.ts
@@ -541,6 +541,25 @@ const commandCases: readonly CommandCase[] = [
 		id: "requests_notifications_replay",
 		outputIncludes: ["Failed to replay notification event"],
 	},
+	{
+		argv: ["audit", "list", "--limit", "10"],
+		expectedExitCode: 0,
+		id: "audit_list",
+		outputIncludes: ['"items":[]'],
+	},
+	{
+		argv: [
+			"audit",
+			"export",
+			"--since",
+			"1970-01-01T00:00:00.000Z",
+			"--format",
+			"jsonl",
+		],
+		expectedExitCode: 0,
+		id: "audit_export",
+		outputIncludes: ['"format":"jsonl"'],
+	},
 ];
 
 const testedCommandIds = new Set(commandCases.map((entry) => entry.id));

--- a/packages/cli/test/e2e/parity-guard.e2e.test.ts
+++ b/packages/cli/test/e2e/parity-guard.e2e.test.ts
@@ -1,15 +1,21 @@
+/* oxlint-disable jest/no-conditional-in-test -- guard test branches on allowlisted command ids. */
 import { describe, expect, it } from "@effect/vitest";
 
 import { allCommands } from "#src/commands/registry";
 import { routeParityMap } from "#src/parity/route-map";
+
+const NON_ROUTE_COMMAND_IDS = new Set(["audit_tail"]);
 
 describe("cLI e2e parity guard", () => {
 	it("covers every registry command id in e2e matrix", () => {
 		const allIds = new Set(allCommands.map((command) => command.id));
 		const matrixIds = new Set(routeParityMap.map((route) => route.id));
 		for (const id of allIds) {
+			if (NON_ROUTE_COMMAND_IDS.has(id)) {
+				continue;
+			}
 			expect(matrixIds.has(id)).toBeTruthy();
 		}
-		expect(matrixIds.size).toBe(allIds.size);
+		expect(matrixIds.size).toBe(allIds.size - NON_ROUTE_COMMAND_IDS.size);
 	});
 });

--- a/packages/internals/persistence/src/index.ts
+++ b/packages/internals/persistence/src/index.ts
@@ -12,6 +12,8 @@ export type {
 export type { PersistenceDriver, PersistenceDriverKind } from "./sql/driver";
 export { TenantContext, withTenant } from "./tenant/context";
 export type {
+	AuditEventCursor,
+	AuditEventPage,
 	AuditEventRecord,
 	ChatRuntimeStateRepository,
 	ChatStateRecord,
@@ -30,6 +32,7 @@ export type {
 	EnsureWebhookEndpointInput,
 	FulfillmentArtifactRecord,
 	JsonValue,
+	ListAuditEventsInput,
 	ListRequestsBySubjectInput,
 	NotificationDeliveryAttemptRecord,
 	NotificationDeliveryStatus,

--- a/packages/internals/persistence/src/services/persistence.ts
+++ b/packages/internals/persistence/src/services/persistence.ts
@@ -5,6 +5,10 @@ import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as ServiceMap from "effect/ServiceMap";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { SqlError } from "effect/unstable/sql/SqlError";
+import type {
+	Fragment as SqlFragment,
+	Statement as SqlStatement,
+} from "effect/unstable/sql/Statement";
 
 import type { PersistenceDriver } from "../sql/driver";
 import { TenantContext, requireTenantId } from "../tenant/context";
@@ -16,6 +20,7 @@ import type {
 	CreateNotificationDeliveryAttemptInput,
 	CreateNotificationEventInput,
 	FulfillmentArtifactsRepository,
+	ListAuditEventsInput,
 	ListRequestsBySubjectInput,
 	NotificationDeliveryAttemptsRepository,
 	NotificationEventsRepository,
@@ -789,6 +794,81 @@ const makePersistence = (
 					LIMIT 1`;
 					const row = yield* findRequired(rows[0], "audit_events", input.id);
 					return mapAuditEventRecord(row);
+				}),
+			list: (input: ListAuditEventsInput) =>
+				Effect.gen(function* listAuditEvents() {
+					const tenantId = yield* requireTenantId;
+					const limit = limitWithFallback(input.limit);
+					const requestIdsFilter =
+						input.requestIds === undefined
+							? undefined
+							: [
+									...new Set(
+										input.requestIds
+											.map((value) => value.trim())
+											.filter((value) => value.length > 0)
+									),
+								];
+					if (requestIdsFilter !== undefined && requestIdsFilter.length === 0) {
+						return { items: [], limit };
+					}
+					const pageLimit = limit + 1;
+					const clauses: (SqlFragment | SqlStatement<unknown>)[] = [
+						sql`tenant_id = ${tenantId}`,
+					];
+					if (input.requestId) {
+						clauses.push(sql`request_id = ${input.requestId}`);
+					}
+					if (requestIdsFilter !== undefined) {
+						clauses.push(sql.in("request_id", requestIdsFilter));
+					}
+					if (input.actor) {
+						clauses.push(sql`actor = ${input.actor}`);
+					}
+					if (input.action) {
+						clauses.push(sql`action = ${input.action}`);
+					}
+					if (input.createdAfter) {
+						clauses.push(sql`created_at >= ${input.createdAfter}`);
+					}
+					if (input.createdBefore) {
+						clauses.push(sql`created_at <= ${input.createdBefore}`);
+					}
+					if (input.cursor) {
+						clauses.push(
+							sql`(created_at < ${input.cursor.createdAt} OR (created_at = ${input.cursor.createdAt} AND id < ${input.cursor.id}))`
+						);
+					}
+					const rows = yield* sql<{
+						readonly id: string;
+						readonly tenant_id: string;
+						readonly request_id: string | null;
+						readonly actor: string;
+						readonly action: string;
+						readonly object: string;
+						readonly before_json: string;
+						readonly after_json: string;
+						readonly reason_json: string;
+						readonly prev_hash: string | null;
+						readonly hash: string;
+						readonly hash_alg: string;
+						readonly sequence: number;
+						readonly created_at: string;
+					}>`SELECT * FROM audit_events
+						WHERE ${sql.and(clauses)}
+						ORDER BY created_at DESC, id DESC
+						LIMIT ${pageLimit}`;
+					const mapped = rows.map(mapAuditEventRecord);
+					const items = mapped.slice(0, limit);
+					const last = items.at(-1);
+					return {
+						items,
+						limit,
+						nextCursor:
+							mapped.length > limit && last
+								? { createdAt: last.createdAt, id: last.id }
+								: undefined,
+					};
 				}),
 			listByRequestId: (requestId) =>
 				Effect.gen(function* listAuditEventsByRequestId() {

--- a/packages/internals/persistence/src/types/domain.ts
+++ b/packages/internals/persistence/src/types/domain.ts
@@ -561,6 +561,56 @@ export interface CreateAuditEventInput {
 }
 
 /**
+ * Stable cursor for audit event list pages.
+ *
+ * @public
+ */
+export interface AuditEventCursor {
+	/** Creation timestamp of the last item returned to the caller. */
+	readonly createdAt: string;
+	/** Audit event id of the last item returned to the caller. */
+	readonly id: string;
+}
+
+/**
+ * Filter contract for tenant-scoped audit event lookup.
+ *
+ * @public
+ */
+export interface ListAuditEventsInput {
+	/** Optional request id filter. */
+	readonly requestId?: string;
+	/** Optional set of request ids (used when expanding a subject filter upstream). */
+	readonly requestIds?: readonly string[];
+	/** Optional actor filter. */
+	readonly actor?: string;
+	/** Optional action filter (the public-facing "event_type"). */
+	readonly action?: string;
+	/** Return records created at or after this ISO timestamp. */
+	readonly createdAfter?: string;
+	/** Return records created at or before this ISO timestamp. */
+	readonly createdBefore?: string;
+	/** Cursor returned by the previous page. */
+	readonly cursor?: AuditEventCursor;
+	/** Maximum rows to read for a single page. */
+	readonly limit?: number;
+}
+
+/**
+ * Cursor-paginated audit event page.
+ *
+ * @public
+ */
+export interface AuditEventPage {
+	/** Matching audit event records in descending creation order. */
+	readonly items: readonly AuditEventRecord[];
+	/** Cursor for the next page when more records are available. */
+	readonly nextCursor?: AuditEventCursor;
+	/** Bounded page size used by the query. */
+	readonly limit: number;
+}
+
+/**
  * Immutable notification generation event record.
  *
  * @public
@@ -1298,6 +1348,22 @@ export interface AuditEventsRepository {
 		requestId: string
 	) => Effect.Effect<
 		readonly AuditEventRecord[],
+		PersistenceError | SqlError,
+		TenantContext
+	>;
+	/**
+	 * Lists audit events for the active tenant filtered by request, actor,
+	 * action, and creation window, paginated with a stable cursor.
+	 *
+	 * @param input - Filter and pagination parameters.
+	 * @returns A cursor-paginated {@link AuditEventPage}.
+	 * @throws {@link PersistenceError} on mapping failures.
+	 * @throws {@link SqlError} on underlying database failures.
+	 */
+	readonly list: (
+		input: ListAuditEventsInput
+	) => Effect.Effect<
+		AuditEventPage,
 		PersistenceError | SqlError,
 		TenantContext
 	>;

--- a/packages/internals/persistence/test/audit-events.list.test.ts
+++ b/packages/internals/persistence/test/audit-events.list.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import { makeSqlitePersistenceLayer } from "../../persistence-sqlite/src";
+import { Persistence, withTenant } from "../src";
+import type { CreateAuditEventInput } from "../src";
+
+const sqliteFile = (name: string): string =>
+	`/tmp/dsar-audit-list-${name}-${crypto.randomUUID()}.sqlite`;
+
+const webhookSigningSecretEncryption = {
+	key: "test-webhook-signing-secret-encryption-key",
+	keyId: "test-key",
+} as const;
+
+const runForTenant = <A>(
+	filename: string,
+	tenantId: string,
+	program: Effect.Effect<A, unknown, Persistence>
+) =>
+	Effect.runPromise(
+		program.pipe(
+			Effect.provide(
+				makeSqlitePersistenceLayer({
+					filename,
+					webhookSigningSecretEncryption,
+				})
+			),
+			withTenant(tenantId)
+		)
+	);
+
+const makeAuditInput = (override: {
+	readonly id: string;
+	readonly sequence: number;
+	readonly createdAt: string;
+	readonly actor?: string;
+	readonly action?: string;
+	readonly requestId?: string;
+	readonly prevHash?: string;
+}): CreateAuditEventInput => ({
+	action: override.action ?? "capture",
+	actor: override.actor ?? "operator-1",
+	after: {},
+	before: {},
+	createdAt: override.createdAt,
+	hash: `hash-${override.id}`,
+	hashAlg: "sha256",
+	id: override.id,
+	object: "request",
+	prevHash: override.prevHash,
+	reason: {},
+	requestId: override.requestId ?? "req-1",
+	sequence: override.sequence,
+});
+
+const seedEvents = (events: readonly CreateAuditEventInput[]) =>
+	Effect.gen(function* seedProgram() {
+		const persistence = yield* Effect.service(Persistence);
+		for (const input of events) {
+			yield* persistence.auditEvents.append(input);
+		}
+	});
+
+describe("auditEvents.list", () => {
+	it("returns events newest-first with cursor when more rows remain", async () => {
+		const dbPath = sqliteFile("cursor");
+		const page = await runForTenant(
+			dbPath,
+			"tenant-a",
+			Effect.gen(function* program() {
+				const persistence = yield* Effect.service(Persistence);
+				yield* seedEvents([
+					makeAuditInput({
+						createdAt: "2026-01-01T00:00:00.000Z",
+						id: "evt-1",
+						sequence: 1,
+					}),
+					makeAuditInput({
+						createdAt: "2026-01-02T00:00:00.000Z",
+						id: "evt-2",
+						sequence: 2,
+					}),
+					makeAuditInput({
+						createdAt: "2026-01-03T00:00:00.000Z",
+						id: "evt-3",
+						sequence: 3,
+					}),
+				]);
+				return yield* persistence.auditEvents.list({ limit: 2 });
+			})
+		);
+		expect(page.items.map((event) => event.id)).toStrictEqual([
+			"evt-3",
+			"evt-2",
+		]);
+		expect(page.nextCursor).toMatchObject({
+			createdAt: "2026-01-02T00:00:00.000Z",
+			id: "evt-2",
+		});
+	});
+
+	it("continues from the returned cursor across pages", async () => {
+		const dbPath = sqliteFile("cursor-continue");
+		const result = await runForTenant(
+			dbPath,
+			"tenant-a",
+			Effect.gen(function* program() {
+				const persistence = yield* Effect.service(Persistence);
+				yield* seedEvents([
+					makeAuditInput({
+						createdAt: "2026-01-01T00:00:00.000Z",
+						id: "evt-1",
+						sequence: 1,
+					}),
+					makeAuditInput({
+						createdAt: "2026-01-02T00:00:00.000Z",
+						id: "evt-2",
+						sequence: 2,
+					}),
+					makeAuditInput({
+						createdAt: "2026-01-03T00:00:00.000Z",
+						id: "evt-3",
+						sequence: 3,
+					}),
+				]);
+				const first = yield* persistence.auditEvents.list({ limit: 2 });
+				const second = yield* persistence.auditEvents.list({
+					cursor: first.nextCursor,
+					limit: 2,
+				});
+				return { first, second };
+			})
+		);
+		expect(result.second.items.map((event) => event.id)).toStrictEqual([
+			"evt-1",
+		]);
+		expect(result.second.nextCursor).toBeUndefined();
+	});
+
+	it("filters by actor, action, request id, and creation window independently", async () => {
+		const dbPath = sqliteFile("filters");
+		const result = await runForTenant(
+			dbPath,
+			"tenant-a",
+			Effect.gen(function* program() {
+				const persistence = yield* Effect.service(Persistence);
+				yield* seedEvents([
+					makeAuditInput({
+						action: "capture",
+						actor: "operator-1",
+						createdAt: "2026-01-01T00:00:00.000Z",
+						id: "evt-1",
+						requestId: "req-1",
+						sequence: 1,
+					}),
+					makeAuditInput({
+						action: "verify",
+						actor: "operator-2",
+						createdAt: "2026-01-02T00:00:00.000Z",
+						id: "evt-2",
+						requestId: "req-1",
+						sequence: 2,
+					}),
+					makeAuditInput({
+						action: "capture",
+						actor: "operator-1",
+						createdAt: "2026-01-03T00:00:00.000Z",
+						id: "evt-3",
+						requestId: "req-2",
+						sequence: 3,
+					}),
+				]);
+				const byActor = yield* persistence.auditEvents.list({
+					actor: "operator-2",
+				});
+				const byAction = yield* persistence.auditEvents.list({
+					action: "capture",
+				});
+				const byRequest = yield* persistence.auditEvents.list({
+					requestId: "req-2",
+				});
+				const inWindow = yield* persistence.auditEvents.list({
+					createdAfter: "2026-01-02T00:00:00.000Z",
+					createdBefore: "2026-01-02T23:59:59.000Z",
+				});
+				return { byAction, byActor, byRequest, inWindow };
+			})
+		);
+		expect(result.byActor.items.map((event) => event.id)).toStrictEqual([
+			"evt-2",
+		]);
+		expect(result.byAction.items.map((event) => event.id)).toStrictEqual([
+			"evt-3",
+			"evt-1",
+		]);
+		expect(result.byRequest.items.map((event) => event.id)).toStrictEqual([
+			"evt-3",
+		]);
+		expect(result.inWindow.items.map((event) => event.id)).toStrictEqual([
+			"evt-2",
+		]);
+	});
+
+	it("returns the empty page when requestIds filter is empty", async () => {
+		const dbPath = sqliteFile("empty-request-ids");
+		const page = await runForTenant(
+			dbPath,
+			"tenant-a",
+			Effect.gen(function* program() {
+				const persistence = yield* Effect.service(Persistence);
+				yield* seedEvents([
+					makeAuditInput({
+						createdAt: "2026-01-01T00:00:00.000Z",
+						id: "evt-1",
+						sequence: 1,
+					}),
+				]);
+				return yield* persistence.auditEvents.list({ requestIds: [] });
+			})
+		);
+		expect(page.items).toStrictEqual([]);
+	});
+
+	it("scopes results to the active tenant", async () => {
+		const dbPath = sqliteFile("tenant-isolation");
+		await runForTenant(
+			dbPath,
+			"tenant-a",
+			seedEvents([
+				makeAuditInput({
+					createdAt: "2026-01-01T00:00:00.000Z",
+					id: "evt-a",
+					sequence: 1,
+				}),
+			])
+		);
+		await runForTenant(
+			dbPath,
+			"tenant-b",
+			seedEvents([
+				makeAuditInput({
+					createdAt: "2026-01-01T00:00:00.000Z",
+					id: "evt-b",
+					sequence: 1,
+				}),
+			])
+		);
+		const tenantA = await runForTenant(
+			dbPath,
+			"tenant-a",
+			Effect.gen(function* program() {
+				const persistence = yield* Effect.service(Persistence);
+				return yield* persistence.auditEvents.list({});
+			})
+		);
+		expect(tenantA.items.map((event) => event.id)).toStrictEqual(["evt-a"]);
+	});
+});


### PR DESCRIPTION
## Summary

Closes #26.

- New tenant-scoped `GET /audit` list endpoint and `GET /audit/export` tenant-wide export, both operator-only, cursor-paginated, with filters for `request_id` / `subject_id` / `actor` / `event_type` / time window. Both back onto a new `auditEvents.list` persistence method that mirrors the existing keyset cursor pattern used for subject lookup.
- Three CLI commands: `dsar audit list`, `dsar audit export --since`, and `dsar audit tail --request` (polling loop, SIGINT-aware, streams events to stdout via a new `ctx.writeLine` plumb-through in the command runtime).
- The audit data source is `audit_events` (immutable hash-chained table), not `request_timeline_events` — matches the existing per-request export at `GET /requests/:id/audit/export`.

## Test plan

- [x] `bun run --filter @dsar/persistence test` — 23 tests, including 5 new for `auditEvents.list` (cursor, filters, tenant isolation)
- [x] `bun run --filter @dsar/backend test` — 98 tests, including 7 new for `/audit` and `/audit/export` (pagination, filters, subject 403, malformed cursor 400, since-required, time window)
- [x] `bun run --filter @dsar/cli test` — 87 tests, including 5 new for the `audit tail` polling loop (advancement, dedup, abort, text format, required flag) + 2 e2e cases for `audit list` / `audit export`
- [x] `bun run --filter @dsar/core --filter @dsar/node-sdk typecheck` clean
- [x] `bun x ultracite check` clean, `oxlint` clean across changed packages
- [x] OpenAPI spec snapshot regenerated to include the new `audit` group
- [ ] End-to-end smoke against `examples/kitchen-sink`: capture a request, hit `dsar audit list`, then `dsar audit tail --request=<id>` while triggering further actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)