### PR TITLE
Add contribution guidelines and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,64 @@
+# Code of Conduct
+
+## Our Pledge
+
+We want DSAR community spaces to be welcoming, respectful, and useful for
+everyone who participates in good faith. Contributors, maintainers, and community
+members are expected to act with care, professionalism, and respect across
+GitHub, Discord, and other official project spaces.
+
+## Expected Behavior
+
+Examples of behavior that supports a healthy community include:
+
+- Being respectful of differing viewpoints and experiences.
+- Giving and receiving constructive feedback with patience.
+- Assuming good intent while still taking responsibility for impact.
+- Keeping discussions focused on the project and the people using it.
+- Crediting sources and prior work where appropriate.
+
+## Unacceptable Behavior
+
+Behavior that is not acceptable includes:
+
+- Harassment, intimidation, threats, or sustained disruption.
+- Insults, demeaning comments, personal attacks, or discriminatory language.
+- Sexualized language or attention in project spaces.
+- Publishing private information without explicit permission.
+- Impersonation, misleading identity, or evading moderation decisions.
+- Spam, promotional content, or off-topic disruption outside community norms.
+
+## Scope
+
+This Code of Conduct applies in all official DSAR community spaces, including
+the GitHub repository, issue tracker, pull requests, discussions, Discord, and
+events or public spaces where someone is representing the project.
+
+## Reporting
+
+If you experience or witness behavior that may violate this Code of Conduct,
+report it privately by emailing support@inth.com. Do not report sensitive conduct
+issues in public GitHub issues or public Discord channels.
+
+Reports should include as much relevant context as you are comfortable sharing,
+such as links, screenshots, dates, names or handles, and a description of what
+happened. Reports will be reviewed promptly and handled with attention to privacy
+and safety.
+
+## Enforcement
+
+Maintainers may take any action they determine is appropriate to protect the
+community, including:
+
+- Clarifying expectations or issuing a private warning.
+- Editing, hiding, or removing comments or contributions.
+- Temporarily limiting participation in project spaces.
+- Permanently banning participation in project spaces.
+
+Enforcement decisions will consider the impact on affected people and the
+community as a whole.
+
+## Updates
+
+The maintainers may update this Code of Conduct as the project and community
+evolve.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to DSAR
+
+Thanks for helping improve DSAR. This project is a Bun-based TypeScript
+monorepo for a developer-first Data Subject Access Request engine.
+
+## Community
+
+- Use GitHub issues for bug reports, feature requests, and focused technical
+  discussions: https://github.com/inthhq/dsar/issues
+- Join the community Discord for questions and informal discussion:
+  https://inth.com/discord
+- Do not report security vulnerabilities or sensitive conduct issues in public
+  GitHub issues or Discord channels.
+
+## Before You Start
+
+1. Search existing issues and pull requests to avoid duplicate work.
+2. Open an issue for substantial changes before investing in implementation.
+3. Keep pull requests focused on one problem or feature.
+
+## Local Development
+
+Install dependencies:
+
+```sh
+bun install
+```
+
+Run the main validation suite:
+
+```sh
+bun run check
+```
+
+Run tests:
+
+```sh
+bun run test
+```
+
+Format and fix common issues:
+
+```sh
+bun x ultracite fix
+```
+
+For package-specific work, prefer the scripts already defined in the relevant
+package and the root workspace scripts in `package.json`.
+
+## Pull Requests
+
+- Create a descriptive branch name for the change.
+- Include a clear summary of what changed and why.
+- Link related issues in the pull request description.
+- Add or update tests when behavior changes.
+- Update documentation when public APIs, commands, or user workflows change.
+- Run the relevant checks before requesting review.
+
+If a change affects a published package, include a changeset:
+
+```sh
+bun run changeset
+```
+
+Choose the smallest accurate release type and describe the user-visible change.
+
+## Code Standards
+
+DSAR uses Ultracite for formatting and linting. Follow the standards in
+`AGENTS.md` and prefer code that is accessible, type-safe, explicit, and easy to
+review. Keep changes scoped to the request and avoid unrelated refactors.
+
+## Security Reports
+
+If you believe you have found a security vulnerability, do not open a public
+issue or discuss it in Discord. Use GitHub private vulnerability reporting at
+https://github.com/inthhq/dsar/security or email support@inth.com.

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ See:
 
 ## Support
 
-- Join our [Discord community](https://c15t.link/discord)
+- Join our [Discord community](https://inth.com/discord)
 - Open an issue on our [GitHub repository](https://github.com/inthhq/dsar/issues)
 - Visit [inth.com](https://inth.com) and use the chat widget
 - Contact our support team via email [support@inth.com](mailto:support@inth.com)
@@ -46,8 +46,8 @@ See:
 ## Contributing
 
 - We're open to all community contributions!
-- Read our [Contribution Guidelines](https://dsar-sdk.dev/docs/oss/contributing)
-- Review our [Code of Conduct](https://dsar-sdk.dev/docs/oss/code-of-conduct)
+- Read our [Contribution Guidelines](CONTRIBUTING.md)
+- Review our [Code of Conduct](CODE_OF_CONDUCT.md)
 - Fork the repository
 - Create a new branch for your feature
 - Submit a pull request
@@ -55,7 +55,7 @@ See:
 
 ## Security
 
-If you believe you have found a security vulnerability in c15t, we encourage you to **_responsibly disclose this and NOT open a public issue_**. We will investigate all legitimate reports.
+If you believe you have found a security vulnerability in DSAR, we encourage you to **_responsibly disclose this and NOT open a public issue_**. We will investigate all legitimate reports.
 
 Our preference is that you make use of GitHub's private vulnerability reporting feature to disclose potential security vulnerabilities in our Open Source Software. To do this, please visit [https://github.com/inthhq/dsar/security](https://github.com/inthhq/dsar/security) and click the "Report a vulnerability" button.
 


### PR DESCRIPTION
## Summary

- Add root contribution guidelines for setup, validation, pull requests, changesets, community channels, and security reporting.
- Add a lightweight project-specific code of conduct covering GitHub, Discord, and other official DSAR spaces.
- Update the root README to point to the new local docs and the preferred Discord URL.

Closes #46.

## Validation

- `bun x ultracite check`